### PR TITLE
feat: integrate claude-mem for AST navigation and cross-session memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin_marketplace-blueviolet)](https://docs.anthropic.com/en/docs/claude-code)
 [![Plugins](https://img.shields.io/badge/plugins-9-green)](plugins/)
-[![Skills](https://img.shields.io/badge/skills-27-green)](plugins/)
+[![Skills](https://img.shields.io/badge/skills-29-green)](plugins/)
 
-A battle-tested Claude Code plugin marketplace — 27 skills, 34 agents, 9 hooks, and 9 commands built over 6+ months of daily use and continuous refinement.
+A battle-tested Claude Code plugin marketplace — 29 skills, 34 agents, 9 hooks, and 9 commands built over 6+ months of daily use and continuous refinement.
 
 ## Why This Exists
 
@@ -50,6 +50,27 @@ Some plugins use MCP servers for enhanced capabilities. These are optional — p
 | [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) | Step-by-step reasoning for complex planning | go-dev, python-dev, typescript-dev, infra-ops, spec-system               |
 | [MorphLLM](https://github.com/morphllm/morph-claude-code)                                               | Fast codebase search and batch file editing | dev-workflow, go-dev, python-dev, typescript-dev, infra-ops, spec-system |
 
+### Claude-Mem Integration
+
+All agents and several skills optionally integrate with [claude-mem](https://github.com/thedotmack/claude-mem) for cross-session memory and AST-based code navigation. Install with:
+
+```bash
+/plugin marketplace add thedotmack/claude-mem
+/plugin install claude-mem@thedotmack
+```
+
+**What this enables:**
+
+| Capability                    | Tools Used                                      | Benefit                                            |
+| ----------------------------- | ----------------------------------------------- | -------------------------------------------------- |
+| AST code navigation           | `smart_search`, `smart_outline`, `smart_unfold` | 10-20x fewer tokens than reading full files        |
+| Cross-session memory          | `search`, `get_observations`, `timeline`        | Find past decisions, known gotchas, recurring bugs |
+| Historical context in reviews | `search` + `get_observations`                   | Review agents check past findings before starting  |
+
+**Graceful degradation**: All plugins work without claude-mem. When it's not installed, MCP tools are silently absent — agents fall back to Read/Grep/Glob, and skills skip history checks. No errors, no configuration needed.
+
+**How it works**: Agent frontmatter lists claude-mem MCP tools alongside standard tools. Claude Code silently omits unavailable tools at runtime, so agents always have their core tools (Read, Grep, Glob, LSP) and gain smart_explore/memory tools when claude-mem is present. Skill instructions use "when available" / "if claude-mem available" phrasing to guide Claude's behavior.
+
 ## Plugins
 
 | Plugin                                                 | Skills | Agents | Description                                                                        |
@@ -60,11 +81,11 @@ Some plugins use MCP servers for enhanced capabilities. These are optional — p
 | [**typescript-dev**](plugins/typescript-dev/README.md) | 1      | 1      | TypeScript with strict typing, React patterns, and modern tooling                  |
 | [**web-dev**](plugins/web-dev/README.md)               | 1      | 1      | Web frontend with vanilla HTML, CSS, JavaScript, and HTMX                          |
 | [**infra-ops**](plugins/infra-ops/README.md)           | 3      | 1      | Kubernetes, Terraform, Helm, GitHub Actions, AWS, GCP                              |
-| [**dev-tools**](plugins/dev-tools/README.md)           | 11     | 2      | Modern CLI, git worktrees, docs lookup, web research, brainstorming, Gemini        |
+| [**dev-tools**](plugins/dev-tools/README.md)           | 13     | 2      | Modern CLI, git worktrees, docs lookup, web research, brainstorming, Gemini        |
 | [**spec-system**](plugins/spec-system/README.md)       | 0      | 1      | Spec-driven development: requirements, tasks, and planning workflows               |
 | [**testing-e2e**](plugins/testing-e2e/README.md)       | 2      | 1      | E2E testing with Playwright: browser automation and test generation                |
 
-**Totals**: 27 skills, 34 agents, 9 hooks, 9 commands
+**Totals**: 29 skills, 34 agents, 9 hooks, 9 commands
 
 ## Skills
 
@@ -74,39 +95,41 @@ Skills teach Claude domain-specific knowledge and workflows. The `skill-enforcer
 
 Invoke as `/skill-name` or let the skill enforcer suggest them.
 
-| Skill                 | What It Does                                     | Example Trigger                |
-| --------------------- | ------------------------------------------------ | ------------------------------ |
-| `brainstorming-ideas` | Collaborative design dialogue before coding      | "brainstorm", "design"         |
-| `committing-code`     | Smart git commits with logical grouping          | "commit", "save changes"       |
-| `debating-ideas`      | Dialectic agents stress-test design decisions    | "debate", "pros and cons"      |
-| `deploying-infra`     | Validate + deploy K8s/Terraform/Helm             | "deploy to staging", "rollout" |
-| `documenting-code`    | Update docs based on recent changes              | "update docs", "document"      |
-| `evolving-config`     | Audit config against latest Claude Code features | "evolve", "audit config"       |
-| `fixing-code`         | Parallel agents fix all issues, zero tolerance   | "fix errors", "make it pass"   |
-| `improving-tests`     | Refactor tests: combine to tabular, fill gaps    | "improve tests", "coverage"    |
-| `looking-up-docs`     | Library documentation via Context7               | "look up docs", "API ref"      |
-| `researching-web`     | Web research via Perplexity AI                   | "research", "X vs Y"           |
-| `reviewing-code`      | Multi-agent review (security, quality, idioms)   | "review code", "check this"    |
-| `testing-e2e`         | Playwright browser automation and test gen       | "e2e test", "playwright"       |
-| `using-gemini`        | Consult Gemini CLI for second opinions           | "ask gemini", "gemini search"  |
+| Skill                 | What It Does                                     | Example Trigger                 |
+| --------------------- | ------------------------------------------------ | ------------------------------- |
+| `brainstorming-ideas` | Collaborative design dialogue before coding      | "brainstorm", "design"          |
+| `committing-code`     | Smart git commits with logical grouping          | "commit", "save changes"        |
+| `debating-ideas`      | Dialectic agents stress-test design decisions    | "debate", "pros and cons"       |
+| `deploying-infra`     | Validate + deploy K8s/Terraform/Helm             | "deploy to staging", "rollout"  |
+| `documenting-code`    | Update docs based on recent changes              | "update docs", "document"       |
+| `evolving-config`     | Audit config against latest Claude Code features | "evolve", "audit config"        |
+| `fixing-code`         | Parallel agents fix all issues, zero tolerance   | "fix errors", "make it pass"    |
+| `improving-tests`     | Refactor tests: combine to tabular, fill gaps    | "improve tests", "coverage"     |
+| `looking-up-docs`     | Library documentation via Context7               | "look up docs", "API ref"       |
+| `mem-history`         | Query past sessions and decisions (claude-mem)   | "last session", "what happened" |
+| `researching-web`     | Web research via Perplexity AI                   | "research", "X vs Y"            |
+| `reviewing-code`      | Multi-agent review (security, quality, idioms)   | "review code", "check this"     |
+| `testing-e2e`         | Playwright browser automation and test gen       | "e2e test", "playwright"        |
+| `using-gemini`        | Consult Gemini CLI for second opinions           | "ask gemini", "gemini search"   |
 
 ### Auto-Activated
 
 These activate silently when the skill enforcer detects matching patterns.
 
-| Skill                 | Activates When                                 |
-| --------------------- | ---------------------------------------------- |
-| `learning-patterns`   | "learn from session", extract learnings        |
-| `managing-infra`      | K8s resources, Terraform, Helm, GitHub Actions |
-| `refactoring-code`    | Multi-file batch changes, rename everywhere    |
-| `searching-code`      | "how does X work", trace flow, find all uses   |
-| `using-cloud-cli`     | bq queries, gcloud/aws commands                |
-| `using-git-worktrees` | Starting feature work needing isolation        |
-| `using-modern-cli`    | rg, fd, bat, eza, sd instead of legacy tools   |
-| `writing-go`          | Go files, go commands, Go-specific terms       |
-| `writing-python`      | Python files, pytest, pip, frameworks          |
-| `writing-typescript`  | TS/TSX files, npm/bun, React, Node.js          |
-| `writing-web`         | HTML/CSS/JS/HTMX templates                     |
+| Skill                 | Activates When                                      |
+| --------------------- | --------------------------------------------------- |
+| `learning-patterns`   | "learn from session", extract learnings             |
+| `managing-infra`      | K8s resources, Terraform, Helm, GitHub Actions      |
+| `refactoring-code`    | Multi-file batch changes, rename everywhere         |
+| `searching-code`      | "how does X work", trace flow, find all uses        |
+| `smart-explore`       | AST code navigation via claude-mem (10-20x savings) |
+| `using-cloud-cli`     | bq queries, gcloud/aws commands                     |
+| `using-git-worktrees` | Starting feature work needing isolation             |
+| `using-modern-cli`    | rg, fd, bat, eza, sd instead of legacy tools        |
+| `writing-go`          | Go files, go commands, Go-specific terms            |
+| `writing-python`      | Python files, pytest, pip, frameworks               |
+| `writing-typescript`  | TS/TSX files, npm/bun, React, Node.js               |
+| `writing-web`         | HTML/CSS/JS/HTMX templates                          |
 
 ## Agents
 

--- a/flat/skills/mem-history
+++ b/flat/skills/mem-history
@@ -1,0 +1,1 @@
+../../plugins/dev-tools/skills/mem-history

--- a/flat/skills/smart-explore
+++ b/flat/skills/smart-explore
@@ -1,0 +1,1 @@
+../../plugins/dev-tools/skills/smart-explore

--- a/plugins/dev-tools/skills/brainstorming-ideas/SKILL.md
+++ b/plugins/dev-tools/skills/brainstorming-ideas/SKILL.md
@@ -11,6 +11,8 @@ allowed-tools:
   - Glob
   - Write
   - mcp__perplexity-ask__perplexity_ask
+  - mcp__plugin_claude-mem_mcp-search__timeline
+  - mcp__plugin_claude-mem_mcp-search__search
   - WebFetch
   - Bash(git *)
 argument-hint: "[<topic>]"
@@ -114,9 +116,9 @@ If "Not sure": flag risky assumptions for verification in Phase 4.
 
 After understanding requirements, **ask before spawning any agents**:
 
-| Header    | Question               | Options                                                                                                                                                                                                       |
-| --------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Next step | How should we proceed? | 1. **Explore codebase** - Check existing patterns and tech stack 2. **Research solutions** - Look up how others solve this 3. **Both** - Explore then research 4. **Skip to approaches** - I know what I want |
+| Header    | Question               | Options                                                                                                                                                                                                                                                                                      |
+| --------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Next step | How should we proceed? | 1. **Explore codebase** - Check existing patterns and tech stack 2. **Research solutions** - Look up how others solve this 3. **Check project history** - Query past decisions on this topic (claude-mem) 4. **Both** - Explore then research 5. **Skip to approaches** - I know what I want |
 
 ### If user chooses "Explore codebase":
 
@@ -129,6 +131,17 @@ Task(
 ```
 
 Then summarize findings and ask: "Based on this, should we also research external solutions?"
+
+### If user chooses "Check project history":
+
+If claude-mem tools are available:
+
+```
+search({ query: "[topic keywords]", limit: 10 })
+timeline({ query: "[topic keywords]", depth_before: 5, depth_after: 5 })
+```
+
+Summarize past decisions, known issues, and relevant context. Then ask if they want to also explore or research.
 
 ### If user chooses "Research solutions":
 

--- a/plugins/dev-tools/skills/mem-history/SKILL.md
+++ b/plugins/dev-tools/skills/mem-history/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: mem-history
+description: Query project history, past decisions, and known gotchas from claude-mem observations. Use when user asks "last session", "did we already", "what did we decide", "project history", "timeline", or "what happened with".
+user-invocable: true
+allowed-tools:
+  - mcp__plugin_claude-mem_mcp-search__search
+  - mcp__plugin_claude-mem_mcp-search__get_observations
+  - mcp__plugin_claude-mem_mcp-search__timeline
+---
+
+# Project Memory Search
+
+Query cross-session history via claude-mem.
+
+**If claude-mem tools are not available**: Tell the user that cross-session memory requires the claude-mem plugin (`/plugin install claude-mem@thedotmack`). Suggest alternatives: check `git log` for recent changes, read CLAUDE.md files for project context, or use `git blame` for file history.
+
+## 3-Layer Workflow
+
+1. **Search** (index): `search` with keywords — returns compact list with IDs (~50-100 tokens/result)
+2. **Get details**: `get_observations` with IDs from search — returns full narratives (~500-1000 tokens/result)
+3. **Timeline**: `timeline` with anchor ID or query — shows chronological context around an observation
+
+## When to Use
+
+| Scenario                        | Action                                            |
+| ------------------------------- | ------------------------------------------------- |
+| "What did we fix last session?" | `search` with file path or feature name           |
+| "Did we try this before?"       | `search` with approach keywords                   |
+| Past decisions on a feature     | `search` → `get_observations` on relevant IDs     |
+| Recurring bug investigation     | `search` type filter for gotchas/problem-solution |
+| Full project timeline           | `timeline` with broad query                       |
+
+## Search Tips
+
+- Use FTS5 syntax: `AND`, `OR`, `NOT`, quoted phrases
+- Filter by type: `gotcha`, `problem-solution`, `decision`, `discovery`
+- Filter by file path for file-specific history
+- Start with small limits (5-10), expand if needed

--- a/plugins/dev-tools/skills/smart-explore/SKILL.md
+++ b/plugins/dev-tools/skills/smart-explore/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: smart-explore
+description: Token-efficient code navigation via AST parsing. Use smart_outline for file structure, smart_search for cross-file discovery, smart_unfold for targeted function extraction. 10-20x fewer tokens than reading full files.
+user-invocable: false
+allowed-tools:
+  - mcp__plugin_claude-mem_mcp-search__smart_search
+  - mcp__plugin_claude-mem_mcp-search__smart_outline
+  - mcp__plugin_claude-mem_mcp-search__smart_unfold
+---
+
+# Smart Explore: AST-Based Code Navigation
+
+Use these tools **when available** (requires claude-mem plugin). Fall back to Read/Grep/Glob if unavailable.
+
+## When to Use Which
+
+| Task                          | Tool            | Tokens    |
+| ----------------------------- | --------------- | --------- |
+| File structure at a glance    | `smart_outline` | ~1,500    |
+| Cross-file symbol discovery   | `smart_search`  | ~3,500    |
+| Read a specific function/type | `smart_unfold`  | ~400-2100 |
+| Simple string search          | Grep            | varies    |
+| Full file needed              | Read            | ~8,000+   |
+
+## Progressive Disclosure Workflow
+
+1. **Outline first**: `smart_outline` shows every function/class/interface with bodies collapsed
+2. **Search if needed**: `smart_search` finds symbols across files by concept
+3. **Unfold targeted**: `smart_unfold` extracts exact function source by AST node — never truncates
+4. **Read only if needed**: Fall back to Read for files where AST parsing isn't useful
+
+## Key Advantages
+
+- **AST-based extraction** guarantees complete function bodies (no truncation)
+- **Structural views** show all symbols without reading full file content
+- **Predictable cost**: 1 tool call per operation, consistent token ranges
+- **Composable**: outline → search → unfold chain naturally

--- a/plugins/dev-workflow/agents/docs-keeper.md
+++ b/plugins/dev-workflow/agents/docs-keeper.md
@@ -12,10 +12,13 @@ tools:
     "LS",
     "mcp__context7__resolve-library-id",
     "mcp__context7__query-docs",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
   ]
 model: sonnet
 color: purple
-skills: ["looking-up-docs"]
+skills: ["looking-up-docs", "smart-explore"]
 ---
 
 You are the **Documentation Keeper** responsible for creating and maintaining comprehensive, clear, and accessible documentation.

--- a/plugins/dev-workflow/agents/go/go-docs.md
+++ b/plugins/dev-workflow/agents/go/go-docs.md
@@ -1,11 +1,22 @@
 ---
 name: go-docs
 description: Go documentation specialist focused on godoc comments, meaningful comments only, and zero test comments. Use for Go code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: haiku
 maxTurns: 10
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/go/go-idioms.md
+++ b/plugins/dev-workflow/agents/go/go-idioms.md
@@ -1,10 +1,21 @@
 ---
 name: go-idioms
 description: Go 1.25+ idioms specialist focused on early returns, short naming, consumer-side interfaces, and stdlib-first patterns. Use for Go code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/go/go-impl.md
+++ b/plugins/dev-workflow/agents/go/go-impl.md
@@ -1,11 +1,22 @@
 ---
 name: go-impl
 description: Go 1.25+ implementation specialist focused on requirements, DI wiring, private interfaces, and testability. Use for Go code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/go/go-qa.md
+++ b/plugins/dev-workflow/agents/go/go-qa.md
@@ -1,12 +1,24 @@
 ---
 name: go-qa
 description: Go 1.25+ QA specialist focused on logic correctness, security (OWASP), and performance. Use for Go code review.
-tools: [Read, Grep, Glob, LS, Bash, LSP, mcp__perplexity-ask__perplexity_ask]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__perplexity-ask__perplexity_ask",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 maxTurns: 15
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/go/go-simplify.md
+++ b/plugins/dev-workflow/agents/go/go-simplify.md
@@ -12,10 +12,13 @@ tools:
     "mcp__perplexity-ask__perplexity_ask",
     "mcp__context7__resolve-library-id",
     "mcp__context7__query-docs",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
   ]
 model: sonnet
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/go/go-tests.md
+++ b/plugins/dev-workflow/agents/go/go-tests.md
@@ -1,10 +1,21 @@
 ---
 name: go-tests
 description: Go testing specialist focused on idiomatic table-driven tests, testify assert/require, mockery EXPECT patterns, and test design quality. Identifies pointless/duplicate tests and recommends implementation refactoring when complex setup signals design problems.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: orange
-skills: ["writing-go"]
+skills: ["writing-go", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-docs.md
+++ b/plugins/dev-workflow/agents/py/py-docs.md
@@ -1,11 +1,22 @@
 ---
 name: py-docs
 description: Python 3.12+ documentation specialist focused on docstrings, README accuracy, and type hints for documentation. Use for Python code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: haiku
 maxTurns: 10
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-idioms.md
+++ b/plugins/dev-workflow/agents/py/py-idioms.md
@@ -1,10 +1,21 @@
 ---
 name: py-idioms
 description: Python 3.12+ idioms specialist focused on Pythonic patterns, PEP8, type hints, and Protocol usage. Use for Python code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-impl.md
+++ b/plugins/dev-workflow/agents/py/py-impl.md
@@ -1,11 +1,22 @@
 ---
 name: py-impl
 description: Python 3.12+ implementation specialist focused on requirements match, dependency injection wiring, and edge cases. Use for Python code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-qa.md
+++ b/plugins/dev-workflow/agents/py/py-qa.md
@@ -1,12 +1,24 @@
 ---
 name: py-qa
 description: Python 3.12+ QA specialist focused on logic correctness, security vulnerabilities, and performance issues. Use for Python code review.
-tools: [Read, Grep, Glob, LS, Bash, LSP, mcp__perplexity-ask__perplexity_ask]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__perplexity-ask__perplexity_ask",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 maxTurns: 15
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-simplify.md
+++ b/plugins/dev-workflow/agents/py/py-simplify.md
@@ -12,10 +12,13 @@ tools:
     "mcp__perplexity-ask__perplexity_ask",
     "mcp__context7__resolve-library-id",
     "mcp__context7__query-docs",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
   ]
 model: sonnet
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/py/py-tests.md
+++ b/plugins/dev-workflow/agents/py/py-tests.md
@@ -1,10 +1,21 @@
 ---
 name: py-tests
 description: Python 3.12+ testing specialist focused on pytest, fixtures, parametrize, and coverage. Use for Python code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: yellow
-skills: ["writing-python"]
+skills: ["writing-python", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-docs.md
+++ b/plugins/dev-workflow/agents/ts/ts-docs.md
@@ -1,11 +1,22 @@
 ---
 name: ts-docs
 description: TypeScript 5.x documentation specialist focused on JSDoc, TSDoc, comment quality, and README accuracy. Use for TypeScript code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: haiku
 maxTurns: 10
 color: blue
-skills: ["writing-typescript"]
+skills: ["writing-typescript", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-idioms.md
+++ b/plugins/dev-workflow/agents/ts/ts-idioms.md
@@ -1,10 +1,21 @@
 ---
 name: ts-idioms
 description: TypeScript 5.x idioms specialist focused on strict typing, discriminated unions, modern patterns (satisfies, as const), and composition. Use for TypeScript code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: blue
-skills: ["writing-typescript"]
+skills: ["writing-typescript", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-impl.md
+++ b/plugins/dev-workflow/agents/ts/ts-impl.md
@@ -1,11 +1,22 @@
 ---
 name: ts-impl
 description: TypeScript 5.x implementation specialist focused on requirements match, dependency injection, runtime validation, and edge cases. Use for TypeScript code review.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 color: blue
-skills: ["writing-typescript"]
+skills: ["writing-typescript", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-qa.md
+++ b/plugins/dev-workflow/agents/ts/ts-qa.md
@@ -1,12 +1,24 @@
 ---
 name: ts-qa
 description: TypeScript 5.x QA specialist focused on logic correctness, security vulnerabilities (OWASP), and performance issues. Use for TypeScript code review.
-tools: [Read, Grep, Glob, LS, Bash, LSP, mcp__perplexity-ask__perplexity_ask]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__perplexity-ask__perplexity_ask",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: opus
 effort: high
 maxTurns: 15
 color: blue
-skills: ["writing-typescript"]
+skills: ["writing-typescript", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-simplify.md
+++ b/plugins/dev-workflow/agents/ts/ts-simplify.md
@@ -12,10 +12,13 @@ tools:
     "mcp__perplexity-ask__perplexity_ask",
     "mcp__context7__resolve-library-id",
     "mcp__context7__query-docs",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
   ]
 model: sonnet
 color: blue
-skills: ["writing-typescript"]
+skills: ["writing-typescript", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/ts/ts-tests.md
+++ b/plugins/dev-workflow/agents/ts/ts-tests.md
@@ -1,10 +1,21 @@
 ---
 name: ts-tests
 description: TypeScript testing specialist focused on Vitest, test.each patterns, React Testing Library, and test design quality. Identifies pointless/duplicate tests and recommends combining with test.each.
-tools: ["Read", "Grep", "Glob", "LS", "Bash", "LSP"]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: blue
-skills: ["writing-typescript", "testing-e2e"]
+skills: ["writing-typescript", "testing-e2e", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-docs.md
+++ b/plugins/dev-workflow/agents/web/web-docs.md
@@ -1,11 +1,22 @@
 ---
 name: web-docs
 description: Web documentation specialist for comments and ARIA labels. Use for HTML/CSS/JS review.
-tools: [Read, Grep, Glob, LS, Bash, LSP]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: haiku
 maxTurns: 10
 color: cyan
-skills: [writing-web]
+skills: ["writing-web", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-idioms.md
+++ b/plugins/dev-workflow/agents/web/web-idioms.md
@@ -1,10 +1,21 @@
 ---
 name: web-idioms
 description: Web idioms specialist for semantic HTML, CSS patterns, and minimal JS. Use for HTML/CSS/JS/HTMX review.
-tools: [Read, Grep, Glob, LS, Bash, LSP]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: cyan
-skills: [writing-web]
+skills: ["writing-web", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-impl.md
+++ b/plugins/dev-workflow/agents/web/web-impl.md
@@ -1,10 +1,21 @@
 ---
 name: web-impl
 description: Web implementation specialist for requirements and responsive design. Use for HTML/CSS/JS/HTMX review.
-tools: [Read, Grep, Glob, LS, Bash, LSP]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: cyan
-skills: [writing-web]
+skills: ["writing-web", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-qa.md
+++ b/plugins/dev-workflow/agents/web/web-qa.md
@@ -1,11 +1,23 @@
 ---
 name: web-qa
 description: Web QA specialist for security, performance, and accessibility basics. Use for HTML/CSS/JS/HTMX review.
-tools: [Read, Grep, Glob, LS, Bash, LSP, mcp__perplexity-ask__perplexity_ask]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__perplexity-ask__perplexity_ask",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 maxTurns: 15
 color: cyan
-skills: [writing-web]
+skills: ["writing-web", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-simplify.md
+++ b/plugins/dev-workflow/agents/web/web-simplify.md
@@ -10,12 +10,15 @@ tools:
     Bash,
     LSP,
     mcp__perplexity-ask__perplexity_ask,
-    mcp__context7__resolve-library-id,
-    mcp__context7__query-docs,
+    "mcp__context7__resolve-library-id",
+    "mcp__context7__query-docs",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
   ]
 model: sonnet
 color: cyan
-skills: [writing-web]
+skills: ["writing-web", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/agents/web/web-tests.md
+++ b/plugins/dev-workflow/agents/web/web-tests.md
@@ -1,10 +1,21 @@
 ---
 name: web-tests
 description: Web testing specialist for E2E tests with Playwright. Use for test code review.
-tools: [Read, Grep, Glob, LS, Bash, LSP]
+tools:
+  [
+    "Read",
+    "Grep",
+    "Glob",
+    "LS",
+    "Bash",
+    "LSP",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+  ]
 model: sonnet
 color: cyan
-skills: [writing-web, testing-e2e]
+skills: ["writing-web", "testing-e2e", "smart-explore"]
 ---
 
 ## Role

--- a/plugins/dev-workflow/hooks/skill-enforcer.sh
+++ b/plugins/dev-workflow/hooks/skill-enforcer.sh
@@ -188,6 +188,18 @@ if echo "$PROMPT_LOWER" | grep -qE '\bask\s*gemini\b|\bgemini\s*(search|opinion|
 	skills+="using-gemini "
 fi
 
+# smart-explore: AST-based code navigation via claude-mem
+# Triggers: code structure, file outline, structural exploration
+if echo "$PROMPT_LOWER" | grep -qE '\b(code|file)\s*structure\b|\boutline\b.*\b(file|code|class|module)\b|\bstructural\s*(view|map|overview)\b|\bwhat.?s\s*in\s*this\s*file\b|\bexplore\s*(the\s*)?(code|codebase)\s*(structure)?\b|\bshow\s*(me\s*)?(the\s*)?(file|code)\s*structure\b|\bast\s*(pars|view|explor)\b|\bsmart[\s_-]?explore\b'; then
+	skills+="smart-explore "
+fi
+
+# mem-history: Query project history via claude-mem
+# Triggers: past sessions, previous decisions, project timeline, memory search
+if echo "$PROMPT_LOWER" | grep -qE '\blast\s*session\b|\bdid\s*we\s*already\b|\bprevious\s*session\b|\bremember\s*when\b|\bwhat\s*did\s*we\s*decide\b|\bpast\s*(issue|bug|decision|fix)\b|\brecurring\s*bug\b|\bproject\s*(history|timeline)\b|\btimeline\b.*\b(project|feature|change)\b|\bwhat\s*happened\s*with\b|\bmem[\s-]?history\b|\bmem[\s-]?search\b|\bclaude[\s-]?mem\b'; then
+	skills+="mem-history "
+fi
+
 # Output only if skills detected (silent when no match)
 if [[ -n "$skills" ]]; then
 	skills="${skills% }"

--- a/plugins/dev-workflow/skills/fixing-code/SKILL.md
+++ b/plugins/dev-workflow/skills/fixing-code/SKILL.md
@@ -16,6 +16,8 @@ allowed-tools:
   - Bash(npm *)
   - Bash(bun *)
   - Bash(bunx *)
+  - mcp__plugin_claude-mem_mcp-search__search
+  - mcp__plugin_claude-mem_mcp-search__get_observations
 ---
 
 # Fix All Issues
@@ -53,6 +55,18 @@ No Makefile? Detect language and run:
 - **Web (HTML/CSS/JS)**: `bunx html-validate "**/*.html" 2>&1 | head -50 && bunx stylelint "**/*.css" 2>&1 | head -50 && bunx eslint "**/*.js" 2>&1 | head -50`
 
 **If all pass**: Report "All checks pass" → stop.
+
+---
+
+## Pre-Phase 2: Check History (if claude-mem available)
+
+If `mcp__plugin_claude-mem_mcp-search__search` is available, query for known issues on failing files:
+
+```
+search({ query: "<failing file paths>", type: "gotcha OR problem-solution", limit: 5 })
+```
+
+If relevant past observations exist, fetch with `get_observations` and attach findings to Phase 2 agent prompts. Skip silently if unavailable.
 
 ---
 

--- a/plugins/dev-workflow/skills/reviewing-code/SKILL.md
+++ b/plugins/dev-workflow/skills/reviewing-code/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - TodoWrite
   - AskUserQuestion
   - Bash
+  - mcp__plugin_claude-mem_mcp-search__search
+  - mcp__plugin_claude-mem_mcp-search__get_observations
 argument-hint: "[deep] [team] [external]"
 ---
 
@@ -40,6 +42,20 @@ argument-hint: "[deep] [team] [external]"
 | external           | go-engineer, python-engineer                                        | Subagent | ✅ Yes                    |
 | team external      | go-engineer, python-engineer                                        | **Team** | ✅ Yes                    |
 | deep team external | All 6-12 specialized sub-agents                                     | **Team** | ✅ Yes                    |
+
+---
+
+## Step 0: Check Historical Context (if claude-mem available)
+
+If `mcp__plugin_claude-mem_mcp-search__search` is available, query for past findings on changed files:
+
+```
+search({ query: "<file paths from git diff --name-only HEAD>", limit: 10 })
+```
+
+Look for past review findings, gotchas (`type: "gotcha"`), and decisions on those files. If relevant observations exist, fetch details with `get_observations` and include key findings in agent prompts (Step 2).
+
+Skip this step silently if claude-mem tools are not available.
 
 ---
 

--- a/plugins/dev-workflow/skills/searching-code/SKILL.md
+++ b/plugins/dev-workflow/skills/searching-code/SKILL.md
@@ -5,6 +5,9 @@ user-invocable: false
 allowed-tools:
   - mcp__morphllm__warpgrep_codebase_search
   - mcp__morphllm__codebase_search
+  - mcp__plugin_claude-mem_mcp-search__smart_search
+  - mcp__plugin_claude-mem_mcp-search__smart_outline
+  - mcp__plugin_claude-mem_mcp-search__smart_unfold
   - Read
   - Grep
   - Glob
@@ -20,15 +23,17 @@ WarpGrep is an RL-trained search agent that reasons about code, not just pattern
 - **4 reasoning turns** (follows causal chains across files)
 - **F1=0.73** in ~3.8 steps (vs 12.4 for standard search)
 
-## When to Use WarpGrep
+## When to Use Which Tool
 
-| Use WarpGrep                | Use Built-in Grep        |
-| --------------------------- | ------------------------ |
-| "How does auth flow work?"  | "Find class UserService" |
-| "Trace data from API to DB" | Simple regex patterns    |
-| "Find all error handling"   | "Where is X defined?"    |
-| Large repos (1000+ files)   | Known file patterns      |
-| Before major refactoring    | Quick needle lookups     |
+| Use WarpGrep                | Use Smart Explore (claude-mem)     | Use Built-in Grep        |
+| --------------------------- | ---------------------------------- | ------------------------ |
+| "How does auth flow work?"  | "What functions are in this file?" | "Find class UserService" |
+| "Trace data from API to DB" | "Show me this function's source"   | Simple regex patterns    |
+| "Find all error handling"   | "Find all types matching X"        | "Where is X defined?"    |
+| Large repos (1000+ files)   | File structure at a glance         | Known file patterns      |
+| Before major refactoring    | Targeted function extraction       | Quick needle lookups     |
+
+**When available**, prefer Smart Explore for structural queries (10-20x fewer tokens). Use WarpGrep for semantic/reasoning queries across files.
 
 ## Query Formulation
 

--- a/plugins/go-dev/agents/go-engineer.md
+++ b/plugins/go-dev/agents/go-engineer.md
@@ -13,10 +13,15 @@ tools:
     "mcp__sequential-thinking__sequentialthinking",
     "mcp__morphllm__warpgrep_codebase_search",
     "mcp__morphllm__codebase_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+    "mcp__plugin_claude-mem_mcp-search__search",
+    "mcp__plugin_claude-mem_mcp-search__get_observations",
   ]
 model: sonnet
 color: orange
-skills: ["writing-go", "looking-up-docs"]
+skills: ["writing-go", "looking-up-docs", "smart-explore", "mem-history"]
 ---
 
 You are an **Expert Go Engineer** specializing in clean architecture, idiomatic Go patterns, and maintainable system design.
@@ -102,6 +107,14 @@ Use `mcp__sequential-thinking__sequentialthinking` for:
 - Complex architectural decisions
 - Large refactoring planning
 - Performance optimization strategies
+
+### Memory (claude-mem)
+
+When available, use `mcp__plugin_claude-mem_mcp-search__*` tools:
+
+- **Before implementing**: Run `get_observations` on files you're about to change to surface past notes and known gotchas
+- **For past decisions**: Run `search` with the feature name or file path to find relevant history
+- **For code navigation**: Prefer `smart_outline` → `smart_unfold` → Read (10-20x fewer tokens)
 
 ## Technical Standards
 

--- a/plugins/infra-ops/agents/infra-engineer.md
+++ b/plugins/infra-ops/agents/infra-engineer.md
@@ -13,10 +13,22 @@ tools:
     mcp__sequential-thinking__sequentialthinking,
     mcp__morphllm__warpgrep_codebase_search,
     mcp__morphllm__codebase_search,
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+    "mcp__plugin_claude-mem_mcp-search__search",
+    "mcp__plugin_claude-mem_mcp-search__get_observations",
   ]
 model: sonnet
 color: green
-skills: ["managing-infra", "using-cloud-cli", "looking-up-docs"]
+skills:
+  [
+    "managing-infra",
+    "using-cloud-cli",
+    "looking-up-docs",
+    "smart-explore",
+    "mem-history",
+  ]
 ---
 
 You are an **Expert Infrastructure Engineer** specializing in Kubernetes, Terraform, CI/CD, and cloud operations.
@@ -161,6 +173,14 @@ gcloud run deploy SERVICE --image=IMAGE --region=REGION
 aws ec2 describe-instances --output json
 aws s3 ls s3://bucket --region us-west-2
 ```
+
+### Memory (claude-mem)
+
+When available, use `mcp__plugin_claude-mem_mcp-search__*` tools:
+
+- **Before implementing**: Run `get_observations` on files you're about to change to surface past notes and known gotchas
+- **For past decisions**: Run `search` with the feature name or file path to find relevant history
+- **For code navigation**: Prefer `smart_outline` → `smart_unfold` → Read (10-20x fewer tokens)
 
 ## Verification Checklist
 

--- a/plugins/python-dev/agents/python-engineer.md
+++ b/plugins/python-dev/agents/python-engineer.md
@@ -13,10 +13,15 @@ tools:
     "mcp__sequential-thinking__sequentialthinking",
     "mcp__morphllm__warpgrep_codebase_search",
     "mcp__morphllm__codebase_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+    "mcp__plugin_claude-mem_mcp-search__search",
+    "mcp__plugin_claude-mem_mcp-search__get_observations",
   ]
 model: sonnet
 color: yellow
-skills: ["writing-python", "looking-up-docs"]
+skills: ["writing-python", "looking-up-docs", "smart-explore", "mem-history"]
 ---
 
 You are an **Expert Python Engineer** specializing in clean architecture, type-safe Python, and maintainable system design.
@@ -114,6 +119,14 @@ Use `mcp__sequential-thinking__sequentialthinking` for:
 - Complex architectural decisions
 - Large refactoring planning
 - Performance optimization strategies
+
+### Memory (claude-mem)
+
+When available, use `mcp__plugin_claude-mem_mcp-search__*` tools:
+
+- **Before implementing**: Run `get_observations` on files you're about to change to surface past notes and known gotchas
+- **For past decisions**: Run `search` with the feature name or file path to find relevant history
+- **For code navigation**: Prefer `smart_outline` → `smart_unfold` → Read (10-20x fewer tokens)
 
 ## Technical Standards
 

--- a/plugins/typescript-dev/agents/typescript-engineer.md
+++ b/plugins/typescript-dev/agents/typescript-engineer.md
@@ -13,10 +13,16 @@ tools:
     "mcp__sequential-thinking__sequentialthinking",
     "mcp__morphllm__warpgrep_codebase_search",
     "mcp__morphllm__codebase_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_search",
+    "mcp__plugin_claude-mem_mcp-search__smart_outline",
+    "mcp__plugin_claude-mem_mcp-search__smart_unfold",
+    "mcp__plugin_claude-mem_mcp-search__search",
+    "mcp__plugin_claude-mem_mcp-search__get_observations",
   ]
 model: sonnet
 color: blue
-skills: ["writing-typescript", "looking-up-docs"]
+skills:
+  ["writing-typescript", "looking-up-docs", "smart-explore", "mem-history"]
 ---
 
 You are an **Expert TypeScript Engineer** specializing in strict typing, modern patterns, and maintainable system design.
@@ -96,6 +102,14 @@ Use `mcp__sequential-thinking__sequentialthinking` for:
 - Complex architectural decisions
 - Large refactoring planning
 - State management design
+
+### Memory (claude-mem)
+
+When available, use `mcp__plugin_claude-mem_mcp-search__*` tools:
+
+- **Before implementing**: Run `get_observations` on files you're about to change to surface past notes and known gotchas
+- **For past decisions**: Run `search` with the feature name or file path to find relevant history
+- **For code navigation**: Prefer `smart_outline` → `smart_unfold` → Read (10-20x fewer tokens)
 
 ## Technical Standards
 

--- a/plugins/web-dev/agents/web-engineer.md
+++ b/plugins/web-dev/agents/web-engineer.md
@@ -10,10 +10,15 @@ tools:
     LS,
     mcp__context7__resolve-library-id,
     mcp__context7__query-docs,
+    mcp__plugin_claude-mem_mcp-search__smart_search,
+    mcp__plugin_claude-mem_mcp-search__smart_outline,
+    mcp__plugin_claude-mem_mcp-search__smart_unfold,
+    mcp__plugin_claude-mem_mcp-search__search,
+    mcp__plugin_claude-mem_mcp-search__get_observations,
   ]
 model: sonnet
 color: cyan
-skills: [writing-web, looking-up-docs]
+skills: [writing-web, looking-up-docs, smart-explore, mem-history]
 ---
 
 ## Role
@@ -142,6 +147,14 @@ document.addEventListener("DOMContentLoaded", () => {
 **Change**: Description
 **Why**: Reason
 ```
+
+### Memory (claude-mem)
+
+When available, use `mcp__plugin_claude-mem_mcp-search__*` tools:
+
+- **Before implementing**: Run `get_observations` on files you're about to change to surface past notes and known gotchas
+- **For past decisions**: Run `search` with the feature name or file path to find relevant history
+- **For code navigation**: Prefer `smart_outline` → `smart_unfold` → Read (10-20x fewer tokens)
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Add optional [claude-mem](https://github.com/thedotmack/claude-mem) integration across all 30 agents and 4 skills for **10-20x token savings** on code navigation and cross-session historical context
- Create 2 new skills: `smart-explore` (AST-based code navigation) and `mem-history` (cross-session memory search)
- All changes use **graceful degradation** — everything works without claude-mem installed; MCP tools are silently absent at runtime

## Changes

### New Skills (2)
- **`smart-explore`** — Non-user-invocable skill providing decision table and progressive disclosure workflow for `smart_outline`, `smart_search`, `smart_unfold` tools
- **`mem-history`** — User-invocable skill for querying past sessions, decisions, gotchas via 3-layer workflow (search → get_observations → timeline). Includes fallback guidance when claude-mem is not installed

### Agent Updates (30 files)
- **25 review agents** (go/py/ts/web x 6 + docs-keeper): Added 3 smart_explore MCP tools + `smart-explore` skill to frontmatter
- **5 engineer agents** (go/python/typescript/web/infra): Added 5 MCP tools (3 smart_explore + search + get_observations), 2 skills, and `### Memory (claude-mem)` body section

### Skill Updates (4 files)
- **`searching-code`**: Extended "When to Use" table with Smart Explore column alongside WarpGrep
- **`reviewing-code`**: Added Step 0 - check claude-mem for past findings on changed files before spawning review agents
- **`fixing-code`**: Added Pre-Phase 2 - query known issues on failing files before analysis
- **`brainstorming-ideas`**: Added "Check project history" option in Phase 3 checkpoint

### Hook Updates (1 file)
- **`skill-enforcer.sh`**: Added detection patterns for `smart-explore` and `mem-history` skills

### Documentation
- README: Added Claude-Mem Integration section, updated skill counts (27 -> 29), added new skills to tables

## Resilience Design

Verified via Claude Code docs + Perplexity research:
- **Missing MCP tools**: Silently omitted from agent tool list at runtime - no errors
- **Missing allowed-tools**: Permission grants for absent tools are simply ignored
- **Missing skills in skills array**: Likely skipped - agent loads without injected content
- **Prose-driven degradation**: All skill instructions use "when available" / "if claude-mem available" / "skip silently if unavailable" phrasing

## Test plan

- [x] `make lint` - 0 errors (shellcheck, shfmt, ruff, markdownlint)
- [x] `make test` - 42/42 tests pass
- [x] `scripts/generate-flat.sh --check` - flat/ in sync (+2 new symlinks)
- [x] Skill enforcer fires correctly for new patterns
- [ ] Manual: Spawn go-idioms agent with claude-mem installed, verify smart_explore tools appear
- [ ] Manual: Invoke /mem-history without claude-mem to verify fallback message