### PR TITLE
fix: improve Pi notification behavior in Kitty + tmux

### DIFF
--- a/dist/claude/plugins/dev-flow/hooks/notify.sh
+++ b/dist/claude/plugins/dev-flow/hooks/notify.sh
@@ -7,11 +7,15 @@
 # Env vars used:
 #   CLAUDE_CODE_VERSION                            - Claude Code detection (title fallback)
 #   KITTY_LISTEN_ON, KITTY_PID, KITTY_WINDOW_ID  - kitty detection + navigation
-#   TMUX_PANE                                      - tmux pane navigation
+#   TMUX, TMUX_PANE                                - tmux server + pane targeting
 #   TERM_PROGRAM                                   - fallback terminal detection
 #   CLAUDE_TERMINAL_BUNDLE_ID                      - manual override (all agents)
 
 set -uo pipefail
+
+shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
 
 # --- Parse input ---
 json_input="${1:-$(cat)}"
@@ -40,12 +44,10 @@ if [[ -n "$cwd" ]]; then
 	title="[$(basename "$cwd")] $title"
 fi
 
-# --- Git context: branch for subtitle, last commit for idle message ---
+# --- Git context: branch for subtitle ---
 git_branch=""
-git_last_commit=""
 if [[ -n "$cwd" && -d "$cwd/.git" ]]; then
 	git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
-	git_last_commit=$(git -C "$cwd" log --oneline -1 2>/dev/null | sed 's/^[a-f0-9]* //' || true)
 fi
 
 # --- Emoji prefix + subtitle by type ---
@@ -63,8 +65,6 @@ idle_prompt)
 	title="💤 $title"
 	subtitle="Waiting for input"
 	[[ -n "$git_branch" ]] && subtitle="$subtitle · $git_branch"
-	# Replace generic agent message with last commit subject (more useful context)
-	[[ -n "$git_last_commit" ]] && message="$git_last_commit"
 	;;
 esac
 
@@ -85,7 +85,19 @@ fi
 kitty_bin=$(command -v kitty 2>/dev/null || echo "/opt/homebrew/bin/kitty")
 tmux_bin=$(command -v tmux 2>/dev/null || echo "/opt/homebrew/bin/tmux")
 
-# --- Detect parent terminal via kitty socket ---
+# --- Discover tmux client metadata (works even when TERM_PROGRAM=tmux) ---
+tmux_client_term=""
+tmux_client_tty=""
+tmux_session_name=""
+tmux_window_index=""
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_client_term=$(tmux display-message -p -t "$TMUX_PANE" '#{client_termname}' 2>/dev/null || true)
+	tmux_client_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{client_tty}' 2>/dev/null || true)
+	tmux_session_name=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null || true)
+	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
+fi
+
+# --- Detect parent terminal via kitty socket or tmux client term ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -95,6 +107,8 @@ fi
 kitty_socket_path="${kitty_socket#unix:}"
 
 if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
+	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 else
 	case "${TERM_PROGRAM:-}" in
@@ -109,17 +123,30 @@ BUNDLE_ID="${CLAUDE_TERMINAL_BUNDLE_ID:-$BUNDLE_ID}"
 
 # --- Build click-to-navigate command (kitty + tmux) ---
 execute_cmd=""
-if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
-	nav_parts=("/usr/bin/open -b net.kovidgoyal.kitty")
+nav_parts=()
+if [[ "$BUNDLE_ID" == "net.kovidgoyal.kitty" ]]; then
+	nav_parts+=("/usr/bin/open -b net.kovidgoyal.kitty")
+fi
 
-	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-		nav_parts+=("${kitty_bin} @ --to ${kitty_socket} focus-tab -m window_id:${KITTY_WINDOW_ID} 2>/dev/null")
+if [[ -n "$kitty_socket" && -S "$kitty_socket_path" && -n "${KITTY_WINDOW_ID:-}" ]]; then
+	nav_parts+=("$(shell_quote "$kitty_bin") @ --to $(shell_quote "$kitty_socket") focus-tab -m window_id:$(shell_quote "$KITTY_WINDOW_ID") 2>/dev/null")
+fi
+
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_prefix="$(shell_quote "$tmux_bin")"
+	if [[ -n "${TMUX:-}" ]]; then
+		tmux_prefix="TMUX=$(shell_quote "$TMUX") $tmux_prefix"
 	fi
-
-	if [[ -n "${TMUX_PANE:-}" ]]; then
-		nav_parts+=("${tmux_bin} select-pane -t ${TMUX_PANE} 2>/dev/null")
+	if [[ -n "$tmux_client_tty" && -n "$tmux_session_name" ]]; then
+		nav_parts+=("$tmux_prefix switch-client -c $(shell_quote "$tmux_client_tty") -t $(shell_quote "$tmux_session_name") 2>/dev/null")
 	fi
+	if [[ -n "$tmux_session_name" && -n "$tmux_window_index" ]]; then
+		nav_parts+=("$tmux_prefix select-window -t $(shell_quote "${tmux_session_name}:${tmux_window_index}") 2>/dev/null")
+	fi
+	nav_parts+=("$tmux_prefix select-pane -t $(shell_quote "$TMUX_PANE") 2>/dev/null")
+fi
 
+if [[ ${#nav_parts[@]} -gt 0 ]]; then
 	execute_cmd=$(printf '%s; ' "${nav_parts[@]}")
 	execute_cmd="${execute_cmd%; }"
 fi

--- a/dist/claude/plugins/dev-flow/hooks/notify.sh
+++ b/dist/claude/plugins/dev-flow/hooks/notify.sh
@@ -97,7 +97,24 @@ if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
 	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
 fi
 
-# --- Detect parent terminal via kitty socket or tmux client term ---
+# --- Skip idle notifications when the user is already viewing this pane ---
+# Cheap tmux focus check: attached session + active window + active pane.
+# Permission prompts are never suppressed — an action-required ping must fire.
+if [[ "$notification_type" == "idle_prompt" && -n "${TMUX_PANE:-}" ]] && command -v tmux &>/dev/null; then
+	pane_state=$(tmux display-message -p -t "$TMUX_PANE" '#{session_attached}:#{window_active}:#{pane_active}' 2>/dev/null || true)
+	if [[ "$pane_state" =~ ^[1-9][0-9]*:1:1$ ]]; then
+		exit 0
+	fi
+fi
+
+# --- Recover the launching terminal when tmux masks TERM_PROGRAM as "tmux" ---
+effective_term="${TERM_PROGRAM:-}"
+if [[ -n "${TMUX_PANE:-}" && (-z "$effective_term" || "$effective_term" == "tmux") ]] && command -v tmux &>/dev/null; then
+	recovered_term=$(tmux show-environment -g TERM_PROGRAM 2>/dev/null | sed -n 's/^TERM_PROGRAM=//p' || true)
+	[[ -n "$recovered_term" ]] && effective_term="$recovered_term"
+fi
+
+# --- Detect parent terminal via kitty socket, tmux client term, or recovered TERM_PROGRAM ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -110,8 +127,10 @@ if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *alacritty* ]]; then
+	BUNDLE_ID="org.alacritty"
 else
-	case "${TERM_PROGRAM:-}" in
+	case "$effective_term" in
 	iTerm.app) BUNDLE_ID="com.googlecode.iterm2" ;;
 	WezTerm) BUNDLE_ID="com.github.wez.wezterm" ;;
 	Alacritty) BUNDLE_ID="org.alacritty" ;;

--- a/dist/codex/plugins/dev-flow/hooks/notify.sh
+++ b/dist/codex/plugins/dev-flow/hooks/notify.sh
@@ -7,11 +7,15 @@
 # Env vars used:
 #   CLAUDE_CODE_VERSION                            - Claude Code detection (title fallback)
 #   KITTY_LISTEN_ON, KITTY_PID, KITTY_WINDOW_ID  - kitty detection + navigation
-#   TMUX_PANE                                      - tmux pane navigation
+#   TMUX, TMUX_PANE                                - tmux server + pane targeting
 #   TERM_PROGRAM                                   - fallback terminal detection
 #   CLAUDE_TERMINAL_BUNDLE_ID                      - manual override (all agents)
 
 set -uo pipefail
+
+shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
 
 # --- Parse input ---
 json_input="${1:-$(cat)}"
@@ -40,12 +44,10 @@ if [[ -n "$cwd" ]]; then
 	title="[$(basename "$cwd")] $title"
 fi
 
-# --- Git context: branch for subtitle, last commit for idle message ---
+# --- Git context: branch for subtitle ---
 git_branch=""
-git_last_commit=""
 if [[ -n "$cwd" && -d "$cwd/.git" ]]; then
 	git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
-	git_last_commit=$(git -C "$cwd" log --oneline -1 2>/dev/null | sed 's/^[a-f0-9]* //' || true)
 fi
 
 # --- Emoji prefix + subtitle by type ---
@@ -63,8 +65,6 @@ idle_prompt)
 	title="💤 $title"
 	subtitle="Waiting for input"
 	[[ -n "$git_branch" ]] && subtitle="$subtitle · $git_branch"
-	# Replace generic agent message with last commit subject (more useful context)
-	[[ -n "$git_last_commit" ]] && message="$git_last_commit"
 	;;
 esac
 
@@ -85,7 +85,19 @@ fi
 kitty_bin=$(command -v kitty 2>/dev/null || echo "/opt/homebrew/bin/kitty")
 tmux_bin=$(command -v tmux 2>/dev/null || echo "/opt/homebrew/bin/tmux")
 
-# --- Detect parent terminal via kitty socket ---
+# --- Discover tmux client metadata (works even when TERM_PROGRAM=tmux) ---
+tmux_client_term=""
+tmux_client_tty=""
+tmux_session_name=""
+tmux_window_index=""
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_client_term=$(tmux display-message -p -t "$TMUX_PANE" '#{client_termname}' 2>/dev/null || true)
+	tmux_client_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{client_tty}' 2>/dev/null || true)
+	tmux_session_name=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null || true)
+	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
+fi
+
+# --- Detect parent terminal via kitty socket or tmux client term ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -95,6 +107,8 @@ fi
 kitty_socket_path="${kitty_socket#unix:}"
 
 if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
+	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 else
 	case "${TERM_PROGRAM:-}" in
@@ -109,17 +123,30 @@ BUNDLE_ID="${CLAUDE_TERMINAL_BUNDLE_ID:-$BUNDLE_ID}"
 
 # --- Build click-to-navigate command (kitty + tmux) ---
 execute_cmd=""
-if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
-	nav_parts=("/usr/bin/open -b net.kovidgoyal.kitty")
+nav_parts=()
+if [[ "$BUNDLE_ID" == "net.kovidgoyal.kitty" ]]; then
+	nav_parts+=("/usr/bin/open -b net.kovidgoyal.kitty")
+fi
 
-	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-		nav_parts+=("${kitty_bin} @ --to ${kitty_socket} focus-tab -m window_id:${KITTY_WINDOW_ID} 2>/dev/null")
+if [[ -n "$kitty_socket" && -S "$kitty_socket_path" && -n "${KITTY_WINDOW_ID:-}" ]]; then
+	nav_parts+=("$(shell_quote "$kitty_bin") @ --to $(shell_quote "$kitty_socket") focus-tab -m window_id:$(shell_quote "$KITTY_WINDOW_ID") 2>/dev/null")
+fi
+
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_prefix="$(shell_quote "$tmux_bin")"
+	if [[ -n "${TMUX:-}" ]]; then
+		tmux_prefix="TMUX=$(shell_quote "$TMUX") $tmux_prefix"
 	fi
-
-	if [[ -n "${TMUX_PANE:-}" ]]; then
-		nav_parts+=("${tmux_bin} select-pane -t ${TMUX_PANE} 2>/dev/null")
+	if [[ -n "$tmux_client_tty" && -n "$tmux_session_name" ]]; then
+		nav_parts+=("$tmux_prefix switch-client -c $(shell_quote "$tmux_client_tty") -t $(shell_quote "$tmux_session_name") 2>/dev/null")
 	fi
+	if [[ -n "$tmux_session_name" && -n "$tmux_window_index" ]]; then
+		nav_parts+=("$tmux_prefix select-window -t $(shell_quote "${tmux_session_name}:${tmux_window_index}") 2>/dev/null")
+	fi
+	nav_parts+=("$tmux_prefix select-pane -t $(shell_quote "$TMUX_PANE") 2>/dev/null")
+fi
 
+if [[ ${#nav_parts[@]} -gt 0 ]]; then
 	execute_cmd=$(printf '%s; ' "${nav_parts[@]}")
 	execute_cmd="${execute_cmd%; }"
 fi

--- a/dist/codex/plugins/dev-flow/hooks/notify.sh
+++ b/dist/codex/plugins/dev-flow/hooks/notify.sh
@@ -97,7 +97,24 @@ if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
 	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
 fi
 
-# --- Detect parent terminal via kitty socket or tmux client term ---
+# --- Skip idle notifications when the user is already viewing this pane ---
+# Cheap tmux focus check: attached session + active window + active pane.
+# Permission prompts are never suppressed — an action-required ping must fire.
+if [[ "$notification_type" == "idle_prompt" && -n "${TMUX_PANE:-}" ]] && command -v tmux &>/dev/null; then
+	pane_state=$(tmux display-message -p -t "$TMUX_PANE" '#{session_attached}:#{window_active}:#{pane_active}' 2>/dev/null || true)
+	if [[ "$pane_state" =~ ^[1-9][0-9]*:1:1$ ]]; then
+		exit 0
+	fi
+fi
+
+# --- Recover the launching terminal when tmux masks TERM_PROGRAM as "tmux" ---
+effective_term="${TERM_PROGRAM:-}"
+if [[ -n "${TMUX_PANE:-}" && (-z "$effective_term" || "$effective_term" == "tmux") ]] && command -v tmux &>/dev/null; then
+	recovered_term=$(tmux show-environment -g TERM_PROGRAM 2>/dev/null | sed -n 's/^TERM_PROGRAM=//p' || true)
+	[[ -n "$recovered_term" ]] && effective_term="$recovered_term"
+fi
+
+# --- Detect parent terminal via kitty socket, tmux client term, or recovered TERM_PROGRAM ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -110,8 +127,10 @@ if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *alacritty* ]]; then
+	BUNDLE_ID="org.alacritty"
 else
-	case "${TERM_PROGRAM:-}" in
+	case "$effective_term" in
 	iTerm.app) BUNDLE_ID="com.googlecode.iterm2" ;;
 	WezTerm) BUNDLE_ID="com.github.wez.wezterm" ;;
 	Alacritty) BUNDLE_ID="org.alacritty" ;;

--- a/dist/gemini/hooks/notify.sh
+++ b/dist/gemini/hooks/notify.sh
@@ -7,11 +7,15 @@
 # Env vars used:
 #   CLAUDE_CODE_VERSION                            - Claude Code detection (title fallback)
 #   KITTY_LISTEN_ON, KITTY_PID, KITTY_WINDOW_ID  - kitty detection + navigation
-#   TMUX_PANE                                      - tmux pane navigation
+#   TMUX, TMUX_PANE                                - tmux server + pane targeting
 #   TERM_PROGRAM                                   - fallback terminal detection
 #   CLAUDE_TERMINAL_BUNDLE_ID                      - manual override (all agents)
 
 set -uo pipefail
+
+shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
 
 # --- Parse input ---
 json_input="${1:-$(cat)}"
@@ -40,12 +44,10 @@ if [[ -n "$cwd" ]]; then
 	title="[$(basename "$cwd")] $title"
 fi
 
-# --- Git context: branch for subtitle, last commit for idle message ---
+# --- Git context: branch for subtitle ---
 git_branch=""
-git_last_commit=""
 if [[ -n "$cwd" && -d "$cwd/.git" ]]; then
 	git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
-	git_last_commit=$(git -C "$cwd" log --oneline -1 2>/dev/null | sed 's/^[a-f0-9]* //' || true)
 fi
 
 # --- Emoji prefix + subtitle by type ---
@@ -63,8 +65,6 @@ idle_prompt)
 	title="💤 $title"
 	subtitle="Waiting for input"
 	[[ -n "$git_branch" ]] && subtitle="$subtitle · $git_branch"
-	# Replace generic agent message with last commit subject (more useful context)
-	[[ -n "$git_last_commit" ]] && message="$git_last_commit"
 	;;
 esac
 
@@ -85,7 +85,19 @@ fi
 kitty_bin=$(command -v kitty 2>/dev/null || echo "/opt/homebrew/bin/kitty")
 tmux_bin=$(command -v tmux 2>/dev/null || echo "/opt/homebrew/bin/tmux")
 
-# --- Detect parent terminal via kitty socket ---
+# --- Discover tmux client metadata (works even when TERM_PROGRAM=tmux) ---
+tmux_client_term=""
+tmux_client_tty=""
+tmux_session_name=""
+tmux_window_index=""
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_client_term=$(tmux display-message -p -t "$TMUX_PANE" '#{client_termname}' 2>/dev/null || true)
+	tmux_client_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{client_tty}' 2>/dev/null || true)
+	tmux_session_name=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null || true)
+	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
+fi
+
+# --- Detect parent terminal via kitty socket or tmux client term ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -95,6 +107,8 @@ fi
 kitty_socket_path="${kitty_socket#unix:}"
 
 if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
+	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 else
 	case "${TERM_PROGRAM:-}" in
@@ -109,17 +123,30 @@ BUNDLE_ID="${CLAUDE_TERMINAL_BUNDLE_ID:-$BUNDLE_ID}"
 
 # --- Build click-to-navigate command (kitty + tmux) ---
 execute_cmd=""
-if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
-	nav_parts=("/usr/bin/open -b net.kovidgoyal.kitty")
+nav_parts=()
+if [[ "$BUNDLE_ID" == "net.kovidgoyal.kitty" ]]; then
+	nav_parts+=("/usr/bin/open -b net.kovidgoyal.kitty")
+fi
 
-	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-		nav_parts+=("${kitty_bin} @ --to ${kitty_socket} focus-tab -m window_id:${KITTY_WINDOW_ID} 2>/dev/null")
+if [[ -n "$kitty_socket" && -S "$kitty_socket_path" && -n "${KITTY_WINDOW_ID:-}" ]]; then
+	nav_parts+=("$(shell_quote "$kitty_bin") @ --to $(shell_quote "$kitty_socket") focus-tab -m window_id:$(shell_quote "$KITTY_WINDOW_ID") 2>/dev/null")
+fi
+
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_prefix="$(shell_quote "$tmux_bin")"
+	if [[ -n "${TMUX:-}" ]]; then
+		tmux_prefix="TMUX=$(shell_quote "$TMUX") $tmux_prefix"
 	fi
-
-	if [[ -n "${TMUX_PANE:-}" ]]; then
-		nav_parts+=("${tmux_bin} select-pane -t ${TMUX_PANE} 2>/dev/null")
+	if [[ -n "$tmux_client_tty" && -n "$tmux_session_name" ]]; then
+		nav_parts+=("$tmux_prefix switch-client -c $(shell_quote "$tmux_client_tty") -t $(shell_quote "$tmux_session_name") 2>/dev/null")
 	fi
+	if [[ -n "$tmux_session_name" && -n "$tmux_window_index" ]]; then
+		nav_parts+=("$tmux_prefix select-window -t $(shell_quote "${tmux_session_name}:${tmux_window_index}") 2>/dev/null")
+	fi
+	nav_parts+=("$tmux_prefix select-pane -t $(shell_quote "$TMUX_PANE") 2>/dev/null")
+fi
 
+if [[ ${#nav_parts[@]} -gt 0 ]]; then
 	execute_cmd=$(printf '%s; ' "${nav_parts[@]}")
 	execute_cmd="${execute_cmd%; }"
 fi

--- a/dist/gemini/hooks/notify.sh
+++ b/dist/gemini/hooks/notify.sh
@@ -97,7 +97,24 @@ if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
 	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
 fi
 
-# --- Detect parent terminal via kitty socket or tmux client term ---
+# --- Skip idle notifications when the user is already viewing this pane ---
+# Cheap tmux focus check: attached session + active window + active pane.
+# Permission prompts are never suppressed — an action-required ping must fire.
+if [[ "$notification_type" == "idle_prompt" && -n "${TMUX_PANE:-}" ]] && command -v tmux &>/dev/null; then
+	pane_state=$(tmux display-message -p -t "$TMUX_PANE" '#{session_attached}:#{window_active}:#{pane_active}' 2>/dev/null || true)
+	if [[ "$pane_state" =~ ^[1-9][0-9]*:1:1$ ]]; then
+		exit 0
+	fi
+fi
+
+# --- Recover the launching terminal when tmux masks TERM_PROGRAM as "tmux" ---
+effective_term="${TERM_PROGRAM:-}"
+if [[ -n "${TMUX_PANE:-}" && (-z "$effective_term" || "$effective_term" == "tmux") ]] && command -v tmux &>/dev/null; then
+	recovered_term=$(tmux show-environment -g TERM_PROGRAM 2>/dev/null | sed -n 's/^TERM_PROGRAM=//p' || true)
+	[[ -n "$recovered_term" ]] && effective_term="$recovered_term"
+fi
+
+# --- Detect parent terminal via kitty socket, tmux client term, or recovered TERM_PROGRAM ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -110,8 +127,10 @@ if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *alacritty* ]]; then
+	BUNDLE_ID="org.alacritty"
 else
-	case "${TERM_PROGRAM:-}" in
+	case "$effective_term" in
 	iTerm.app) BUNDLE_ID="com.googlecode.iterm2" ;;
 	WezTerm) BUNDLE_ID="com.github.wez.wezterm" ;;
 	Alacritty) BUNDLE_ID="org.alacritty" ;;

--- a/dist/pi/hooks/notify.sh
+++ b/dist/pi/hooks/notify.sh
@@ -7,11 +7,15 @@
 # Env vars used:
 #   CLAUDE_CODE_VERSION                            - Claude Code detection (title fallback)
 #   KITTY_LISTEN_ON, KITTY_PID, KITTY_WINDOW_ID  - kitty detection + navigation
-#   TMUX_PANE                                      - tmux pane navigation
+#   TMUX, TMUX_PANE                                - tmux server + pane targeting
 #   TERM_PROGRAM                                   - fallback terminal detection
 #   CLAUDE_TERMINAL_BUNDLE_ID                      - manual override (all agents)
 
 set -uo pipefail
+
+shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
 
 # --- Parse input ---
 json_input="${1:-$(cat)}"
@@ -40,12 +44,10 @@ if [[ -n "$cwd" ]]; then
 	title="[$(basename "$cwd")] $title"
 fi
 
-# --- Git context: branch for subtitle, last commit for idle message ---
+# --- Git context: branch for subtitle ---
 git_branch=""
-git_last_commit=""
 if [[ -n "$cwd" && -d "$cwd/.git" ]]; then
 	git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
-	git_last_commit=$(git -C "$cwd" log --oneline -1 2>/dev/null | sed 's/^[a-f0-9]* //' || true)
 fi
 
 # --- Emoji prefix + subtitle by type ---
@@ -63,8 +65,6 @@ idle_prompt)
 	title="💤 $title"
 	subtitle="Waiting for input"
 	[[ -n "$git_branch" ]] && subtitle="$subtitle · $git_branch"
-	# Replace generic agent message with last commit subject (more useful context)
-	[[ -n "$git_last_commit" ]] && message="$git_last_commit"
 	;;
 esac
 
@@ -85,7 +85,19 @@ fi
 kitty_bin=$(command -v kitty 2>/dev/null || echo "/opt/homebrew/bin/kitty")
 tmux_bin=$(command -v tmux 2>/dev/null || echo "/opt/homebrew/bin/tmux")
 
-# --- Detect parent terminal via kitty socket ---
+# --- Discover tmux client metadata (works even when TERM_PROGRAM=tmux) ---
+tmux_client_term=""
+tmux_client_tty=""
+tmux_session_name=""
+tmux_window_index=""
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_client_term=$(tmux display-message -p -t "$TMUX_PANE" '#{client_termname}' 2>/dev/null || true)
+	tmux_client_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{client_tty}' 2>/dev/null || true)
+	tmux_session_name=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null || true)
+	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
+fi
+
+# --- Detect parent terminal via kitty socket or tmux client term ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -95,6 +107,8 @@ fi
 kitty_socket_path="${kitty_socket#unix:}"
 
 if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
+	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 else
 	case "${TERM_PROGRAM:-}" in
@@ -109,17 +123,30 @@ BUNDLE_ID="${CLAUDE_TERMINAL_BUNDLE_ID:-$BUNDLE_ID}"
 
 # --- Build click-to-navigate command (kitty + tmux) ---
 execute_cmd=""
-if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
-	nav_parts=("/usr/bin/open -b net.kovidgoyal.kitty")
+nav_parts=()
+if [[ "$BUNDLE_ID" == "net.kovidgoyal.kitty" ]]; then
+	nav_parts+=("/usr/bin/open -b net.kovidgoyal.kitty")
+fi
 
-	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-		nav_parts+=("${kitty_bin} @ --to ${kitty_socket} focus-tab -m window_id:${KITTY_WINDOW_ID} 2>/dev/null")
+if [[ -n "$kitty_socket" && -S "$kitty_socket_path" && -n "${KITTY_WINDOW_ID:-}" ]]; then
+	nav_parts+=("$(shell_quote "$kitty_bin") @ --to $(shell_quote "$kitty_socket") focus-tab -m window_id:$(shell_quote "$KITTY_WINDOW_ID") 2>/dev/null")
+fi
+
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_prefix="$(shell_quote "$tmux_bin")"
+	if [[ -n "${TMUX:-}" ]]; then
+		tmux_prefix="TMUX=$(shell_quote "$TMUX") $tmux_prefix"
 	fi
-
-	if [[ -n "${TMUX_PANE:-}" ]]; then
-		nav_parts+=("${tmux_bin} select-pane -t ${TMUX_PANE} 2>/dev/null")
+	if [[ -n "$tmux_client_tty" && -n "$tmux_session_name" ]]; then
+		nav_parts+=("$tmux_prefix switch-client -c $(shell_quote "$tmux_client_tty") -t $(shell_quote "$tmux_session_name") 2>/dev/null")
 	fi
+	if [[ -n "$tmux_session_name" && -n "$tmux_window_index" ]]; then
+		nav_parts+=("$tmux_prefix select-window -t $(shell_quote "${tmux_session_name}:${tmux_window_index}") 2>/dev/null")
+	fi
+	nav_parts+=("$tmux_prefix select-pane -t $(shell_quote "$TMUX_PANE") 2>/dev/null")
+fi
 
+if [[ ${#nav_parts[@]} -gt 0 ]]; then
 	execute_cmd=$(printf '%s; ' "${nav_parts[@]}")
 	execute_cmd="${execute_cmd%; }"
 fi

--- a/dist/pi/hooks/notify.sh
+++ b/dist/pi/hooks/notify.sh
@@ -97,7 +97,24 @@ if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
 	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
 fi
 
-# --- Detect parent terminal via kitty socket or tmux client term ---
+# --- Skip idle notifications when the user is already viewing this pane ---
+# Cheap tmux focus check: attached session + active window + active pane.
+# Permission prompts are never suppressed — an action-required ping must fire.
+if [[ "$notification_type" == "idle_prompt" && -n "${TMUX_PANE:-}" ]] && command -v tmux &>/dev/null; then
+	pane_state=$(tmux display-message -p -t "$TMUX_PANE" '#{session_attached}:#{window_active}:#{pane_active}' 2>/dev/null || true)
+	if [[ "$pane_state" =~ ^[1-9][0-9]*:1:1$ ]]; then
+		exit 0
+	fi
+fi
+
+# --- Recover the launching terminal when tmux masks TERM_PROGRAM as "tmux" ---
+effective_term="${TERM_PROGRAM:-}"
+if [[ -n "${TMUX_PANE:-}" && (-z "$effective_term" || "$effective_term" == "tmux") ]] && command -v tmux &>/dev/null; then
+	recovered_term=$(tmux show-environment -g TERM_PROGRAM 2>/dev/null | sed -n 's/^TERM_PROGRAM=//p' || true)
+	[[ -n "$recovered_term" ]] && effective_term="$recovered_term"
+fi
+
+# --- Detect parent terminal via kitty socket, tmux client term, or recovered TERM_PROGRAM ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -110,8 +127,10 @@ if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *alacritty* ]]; then
+	BUNDLE_ID="org.alacritty"
 else
-	case "${TERM_PROGRAM:-}" in
+	case "$effective_term" in
 	iTerm.app) BUNDLE_ID="com.googlecode.iterm2" ;;
 	WezTerm) BUNDLE_ID="com.github.wez.wezterm" ;;
 	Alacritty) BUNDLE_ID="org.alacritty" ;;

--- a/src/hooks/notify/hook.sh
+++ b/src/hooks/notify/hook.sh
@@ -7,11 +7,15 @@
 # Env vars used:
 #   CLAUDE_CODE_VERSION                            - Claude Code detection (title fallback)
 #   KITTY_LISTEN_ON, KITTY_PID, KITTY_WINDOW_ID  - kitty detection + navigation
-#   TMUX_PANE                                      - tmux pane navigation
+#   TMUX, TMUX_PANE                                - tmux server + pane targeting
 #   TERM_PROGRAM                                   - fallback terminal detection
 #   CLAUDE_TERMINAL_BUNDLE_ID                      - manual override (all agents)
 
 set -uo pipefail
+
+shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\''/g")"
+}
 
 # --- Parse input ---
 json_input="${1:-$(cat)}"
@@ -40,12 +44,10 @@ if [[ -n "$cwd" ]]; then
 	title="[$(basename "$cwd")] $title"
 fi
 
-# --- Git context: branch for subtitle, last commit for idle message ---
+# --- Git context: branch for subtitle ---
 git_branch=""
-git_last_commit=""
 if [[ -n "$cwd" && -d "$cwd/.git" ]]; then
 	git_branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
-	git_last_commit=$(git -C "$cwd" log --oneline -1 2>/dev/null | sed 's/^[a-f0-9]* //' || true)
 fi
 
 # --- Emoji prefix + subtitle by type ---
@@ -63,8 +65,6 @@ idle_prompt)
 	title="💤 $title"
 	subtitle="Waiting for input"
 	[[ -n "$git_branch" ]] && subtitle="$subtitle · $git_branch"
-	# Replace generic agent message with last commit subject (more useful context)
-	[[ -n "$git_last_commit" ]] && message="$git_last_commit"
 	;;
 esac
 
@@ -85,7 +85,19 @@ fi
 kitty_bin=$(command -v kitty 2>/dev/null || echo "/opt/homebrew/bin/kitty")
 tmux_bin=$(command -v tmux 2>/dev/null || echo "/opt/homebrew/bin/tmux")
 
-# --- Detect parent terminal via kitty socket ---
+# --- Discover tmux client metadata (works even when TERM_PROGRAM=tmux) ---
+tmux_client_term=""
+tmux_client_tty=""
+tmux_session_name=""
+tmux_window_index=""
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_client_term=$(tmux display-message -p -t "$TMUX_PANE" '#{client_termname}' 2>/dev/null || true)
+	tmux_client_tty=$(tmux display-message -p -t "$TMUX_PANE" '#{client_tty}' 2>/dev/null || true)
+	tmux_session_name=$(tmux display-message -p -t "$TMUX_PANE" '#{session_name}' 2>/dev/null || true)
+	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
+fi
+
+# --- Detect parent terminal via kitty socket or tmux client term ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -95,6 +107,8 @@ fi
 kitty_socket_path="${kitty_socket#unix:}"
 
 if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
+	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 else
 	case "${TERM_PROGRAM:-}" in
@@ -109,17 +123,30 @@ BUNDLE_ID="${CLAUDE_TERMINAL_BUNDLE_ID:-$BUNDLE_ID}"
 
 # --- Build click-to-navigate command (kitty + tmux) ---
 execute_cmd=""
-if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
-	nav_parts=("/usr/bin/open -b net.kovidgoyal.kitty")
+nav_parts=()
+if [[ "$BUNDLE_ID" == "net.kovidgoyal.kitty" ]]; then
+	nav_parts+=("/usr/bin/open -b net.kovidgoyal.kitty")
+fi
 
-	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-		nav_parts+=("${kitty_bin} @ --to ${kitty_socket} focus-tab -m window_id:${KITTY_WINDOW_ID} 2>/dev/null")
+if [[ -n "$kitty_socket" && -S "$kitty_socket_path" && -n "${KITTY_WINDOW_ID:-}" ]]; then
+	nav_parts+=("$(shell_quote "$kitty_bin") @ --to $(shell_quote "$kitty_socket") focus-tab -m window_id:$(shell_quote "$KITTY_WINDOW_ID") 2>/dev/null")
+fi
+
+if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
+	tmux_prefix="$(shell_quote "$tmux_bin")"
+	if [[ -n "${TMUX:-}" ]]; then
+		tmux_prefix="TMUX=$(shell_quote "$TMUX") $tmux_prefix"
 	fi
-
-	if [[ -n "${TMUX_PANE:-}" ]]; then
-		nav_parts+=("${tmux_bin} select-pane -t ${TMUX_PANE} 2>/dev/null")
+	if [[ -n "$tmux_client_tty" && -n "$tmux_session_name" ]]; then
+		nav_parts+=("$tmux_prefix switch-client -c $(shell_quote "$tmux_client_tty") -t $(shell_quote "$tmux_session_name") 2>/dev/null")
 	fi
+	if [[ -n "$tmux_session_name" && -n "$tmux_window_index" ]]; then
+		nav_parts+=("$tmux_prefix select-window -t $(shell_quote "${tmux_session_name}:${tmux_window_index}") 2>/dev/null")
+	fi
+	nav_parts+=("$tmux_prefix select-pane -t $(shell_quote "$TMUX_PANE") 2>/dev/null")
+fi
 
+if [[ ${#nav_parts[@]} -gt 0 ]]; then
 	execute_cmd=$(printf '%s; ' "${nav_parts[@]}")
 	execute_cmd="${execute_cmd%; }"
 fi

--- a/src/hooks/notify/hook.sh
+++ b/src/hooks/notify/hook.sh
@@ -97,7 +97,24 @@ if command -v tmux &>/dev/null && [[ -n "${TMUX_PANE:-}" ]]; then
 	tmux_window_index=$(tmux display-message -p -t "$TMUX_PANE" '#{window_index}' 2>/dev/null || true)
 fi
 
-# --- Detect parent terminal via kitty socket or tmux client term ---
+# --- Skip idle notifications when the user is already viewing this pane ---
+# Cheap tmux focus check: attached session + active window + active pane.
+# Permission prompts are never suppressed — an action-required ping must fire.
+if [[ "$notification_type" == "idle_prompt" && -n "${TMUX_PANE:-}" ]] && command -v tmux &>/dev/null; then
+	pane_state=$(tmux display-message -p -t "$TMUX_PANE" '#{session_attached}:#{window_active}:#{pane_active}' 2>/dev/null || true)
+	if [[ "$pane_state" =~ ^[1-9][0-9]*:1:1$ ]]; then
+		exit 0
+	fi
+fi
+
+# --- Recover the launching terminal when tmux masks TERM_PROGRAM as "tmux" ---
+effective_term="${TERM_PROGRAM:-}"
+if [[ -n "${TMUX_PANE:-}" && (-z "$effective_term" || "$effective_term" == "tmux") ]] && command -v tmux &>/dev/null; then
+	recovered_term=$(tmux show-environment -g TERM_PROGRAM 2>/dev/null | sed -n 's/^TERM_PROGRAM=//p' || true)
+	[[ -n "$recovered_term" ]] && effective_term="$recovered_term"
+fi
+
+# --- Detect parent terminal via kitty socket, tmux client term, or recovered TERM_PROGRAM ---
 kitty_socket=""
 if [[ -n "${KITTY_LISTEN_ON:-}" ]]; then
 	kitty_socket="$KITTY_LISTEN_ON"
@@ -110,8 +127,10 @@ if [[ -n "$kitty_socket" && -S "$kitty_socket_path" ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
 elif [[ "$tmux_client_term" == *kitty* ]]; then
 	BUNDLE_ID="net.kovidgoyal.kitty"
+elif [[ "$tmux_client_term" == *alacritty* ]]; then
+	BUNDLE_ID="org.alacritty"
 else
-	case "${TERM_PROGRAM:-}" in
+	case "$effective_term" in
 	iTerm.app) BUNDLE_ID="com.googlecode.iterm2" ;;
 	WezTerm) BUNDLE_ID="com.github.wez.wezterm" ;;
 	Alacritty) BUNDLE_ID="org.alacritty" ;;

--- a/tests/hooks/test_notify.py
+++ b/tests/hooks/test_notify.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+from conftest import REPO_ROOT
+
+HOOK = REPO_ROOT / "src" / "hooks" / "notify" / "hook.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _run(
+    payload: dict[str, str], cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+        timeout=5,
+        check=False,
+    )
+
+
+def _arg_after(args: list[str], flag: str) -> str:
+    idx = args.index(flag)
+    return args[idx + 1]
+
+
+def test_idle_prompt_keeps_ready_message_and_targets_kitty_via_tmux(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".git").mkdir()
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    notifier_args = tmp_path / "terminal-notifier.args"
+
+    _write_executable(
+        bin_dir / "terminal-notifier",
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            printf '%s\n' "$@" > {shlex.quote(str(notifier_args))}
+            """
+        ),
+    )
+    _write_executable(
+        bin_dir / "tmux",
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            case "$*" in
+            *"#{client_termname}"*) echo "xterm-kitty" ;;
+            *"#{client_tty}"*) echo "/dev/ttys001" ;;
+            *"#{session_name}"*) echo "ccgram" ;;
+            *"#{window_index}"*) echo "2" ;;
+            *) exit 1 ;;
+            esac
+            """
+        ),
+    )
+    _write_executable(
+        bin_dir / "git",
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            if [[ "$1" == "-C" ]]; then
+                shift 2
+            fi
+            if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then
+                echo "master"
+                exit 0
+            fi
+            if [[ "$1" == "log" && "$2" == "--oneline" ]]; then
+                echo "abc123 ruff running in pre-commit hooks"
+                exit 0
+            fi
+            exit 1
+            """
+        ),
+    )
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["TERM_PROGRAM"] = "tmux"
+    env["TMUX"] = "/tmp/tmux-sock,1,0"
+    env["TMUX_PANE"] = "%49"
+    env.pop("KITTY_LISTEN_ON", None)
+    env.pop("KITTY_PID", None)
+    env.pop("KITTY_WINDOW_ID", None)
+    env.pop("CLAUDE_TERMINAL_BUNDLE_ID", None)
+
+    proc = _run(
+        {
+            "title": "Pi",
+            "message": "Ready for input",
+            "notification_type": "idle_prompt",
+            "cwd": str(project),
+            "session_id": "s1",
+        },
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    args = notifier_args.read_text().splitlines()
+
+    assert _arg_after(args, "-activate") == "net.kovidgoyal.kitty"
+    assert _arg_after(args, "-message") == "Ready for input"
+    assert "ruff running in pre-commit hooks" not in "\n".join(args)
+
+    execute = _arg_after(args, "-execute")
+    assert "open -b net.kovidgoyal.kitty" in execute
+    assert "switch-client" in execute
+    assert "/dev/ttys001" in execute
+    assert "select-window" in execute
+    assert "ccgram:2" in execute
+    assert "select-pane" in execute
+    assert "%49" in execute

--- a/tests/hooks/test_notify.py
+++ b/tests/hooks/test_notify.py
@@ -18,6 +18,94 @@ def _write_executable(path: Path, content: str) -> None:
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
 
 
+def _write_terminal_notifier(bin_dir: Path, args_file: Path) -> None:
+    _write_executable(
+        bin_dir / "terminal-notifier",
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            printf '%s\n' "$@" > {shlex.quote(str(args_file))}
+            """
+        ),
+    )
+
+
+def _write_git(bin_dir: Path) -> None:
+    _write_executable(
+        bin_dir / "git",
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            if [[ "$1" == "-C" ]]; then
+                shift 2
+            fi
+            if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then
+                echo "master"
+                exit 0
+            fi
+            if [[ "$1" == "log" && "$2" == "--oneline" ]]; then
+                echo "abc123 ruff running in pre-commit hooks"
+                exit 0
+            fi
+            exit 1
+            """
+        ),
+    )
+
+
+def _write_tmux(
+    bin_dir: Path,
+    *,
+    term: str = "xterm-256color",
+    tty: str = "/dev/ttys001",
+    session: str = "main",
+    window: str = "0",
+    attached: str = "1",
+    window_active: str = "0",
+    pane_active: str = "0",
+    term_program_global: str = "",
+) -> None:
+    """Mock tmux. term_program_global="" means TERM_PROGRAM unset in server env."""
+    env_line = (
+        f"TERM_PROGRAM={term_program_global}"
+        if term_program_global
+        else "-TERM_PROGRAM"
+    )
+    focus = f"{attached}:{window_active}:{pane_active}"
+    _write_executable(
+        bin_dir / "tmux",
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            case "$*" in
+            *"show-environment"*) echo {shlex.quote(env_line)} ;;
+            *"session_attached"*) echo {shlex.quote(focus)} ;;
+            *"#{{client_termname}}"*) echo {shlex.quote(term)} ;;
+            *"#{{client_tty}}"*) echo {shlex.quote(tty)} ;;
+            *"#{{session_name}}"*) echo {shlex.quote(session)} ;;
+            *"#{{window_index}}"*) echo {shlex.quote(window)} ;;
+            *) exit 1 ;;
+            esac
+            """
+        ),
+    )
+
+
+def _tmux_env(env: dict[str, str], bin_dir: Path) -> dict[str, str]:
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["TERM_PROGRAM"] = "tmux"
+    env["TMUX"] = "/tmp/tmux-sock,1,0"
+    env["TMUX_PANE"] = "%49"
+    for var in (
+        "KITTY_LISTEN_ON",
+        "KITTY_PID",
+        "KITTY_WINDOW_ID",
+        "CLAUDE_TERMINAL_BUNDLE_ID",
+    ):
+        env.pop(var, None)
+    return env
+
+
 def _run(
     payload: dict[str, str], cwd: Path, env: dict[str, str]
 ) -> subprocess.CompletedProcess[str]:
@@ -49,60 +137,12 @@ def test_idle_prompt_keeps_ready_message_and_targets_kitty_via_tmux(
     bin_dir.mkdir()
     notifier_args = tmp_path / "terminal-notifier.args"
 
-    _write_executable(
-        bin_dir / "terminal-notifier",
-        textwrap.dedent(
-            f"""\
-            #!/usr/bin/env bash
-            printf '%s\n' "$@" > {shlex.quote(str(notifier_args))}
-            """
-        ),
-    )
-    _write_executable(
-        bin_dir / "tmux",
-        textwrap.dedent(
-            """\
-            #!/usr/bin/env bash
-            case "$*" in
-            *"#{client_termname}"*) echo "xterm-kitty" ;;
-            *"#{client_tty}"*) echo "/dev/ttys001" ;;
-            *"#{session_name}"*) echo "ccgram" ;;
-            *"#{window_index}"*) echo "2" ;;
-            *) exit 1 ;;
-            esac
-            """
-        ),
-    )
-    _write_executable(
-        bin_dir / "git",
-        textwrap.dedent(
-            """\
-            #!/usr/bin/env bash
-            if [[ "$1" == "-C" ]]; then
-                shift 2
-            fi
-            if [[ "$1" == "branch" && "$2" == "--show-current" ]]; then
-                echo "master"
-                exit 0
-            fi
-            if [[ "$1" == "log" && "$2" == "--oneline" ]]; then
-                echo "abc123 ruff running in pre-commit hooks"
-                exit 0
-            fi
-            exit 1
-            """
-        ),
-    )
+    _write_terminal_notifier(bin_dir, notifier_args)
+    _write_git(bin_dir)
+    # client is kitty, but the pane is not focused → notification must fire.
+    _write_tmux(bin_dir, term="xterm-kitty", session="ccgram", window="2")
 
-    env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}:{env['PATH']}"
-    env["TERM_PROGRAM"] = "tmux"
-    env["TMUX"] = "/tmp/tmux-sock,1,0"
-    env["TMUX_PANE"] = "%49"
-    env.pop("KITTY_LISTEN_ON", None)
-    env.pop("KITTY_PID", None)
-    env.pop("KITTY_WINDOW_ID", None)
-    env.pop("CLAUDE_TERMINAL_BUNDLE_ID", None)
+    env = _tmux_env(os.environ.copy(), bin_dir)
 
     proc = _run(
         {
@@ -131,3 +171,147 @@ def test_idle_prompt_keeps_ready_message_and_targets_kitty_via_tmux(
     assert "ccgram:2" in execute
     assert "select-pane" in execute
     assert "%49" in execute
+
+
+def test_idle_prompt_suppressed_when_pane_focused(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    notifier_args = tmp_path / "terminal-notifier.args"
+
+    _write_terminal_notifier(bin_dir, notifier_args)
+    # attached + active window + active pane → user is already looking at it.
+    _write_tmux(bin_dir, term="xterm-kitty", window_active="1", pane_active="1")
+
+    env = _tmux_env(os.environ.copy(), bin_dir)
+
+    proc = _run(
+        {
+            "title": "Pi",
+            "message": "Ready for input",
+            "notification_type": "idle_prompt",
+            "session_id": "s1",
+        },
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert not notifier_args.exists(), "focused idle prompt should not notify"
+
+
+def test_permission_prompt_not_suppressed_when_pane_focused(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    notifier_args = tmp_path / "terminal-notifier.args"
+
+    _write_terminal_notifier(bin_dir, notifier_args)
+    # focused pane — but permission prompts must always fire.
+    _write_tmux(bin_dir, term="xterm-kitty", window_active="1", pane_active="1")
+
+    env = _tmux_env(os.environ.copy(), bin_dir)
+
+    proc = _run(
+        {
+            "title": "Pi",
+            "message": "Allow shell command?",
+            "notification_type": "permission_prompt",
+            "session_id": "s1",
+        },
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    args = notifier_args.read_text().splitlines()
+    assert _arg_after(args, "-subtitle") == "Action required"
+    assert _arg_after(args, "-activate") == "net.kovidgoyal.kitty"
+
+
+def test_iterm_under_tmux_recovers_bundle_id(tmp_path: Path) -> None:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    notifier_args = tmp_path / "terminal-notifier.args"
+
+    _write_terminal_notifier(bin_dir, notifier_args)
+    # Inside tmux TERM_PROGRAM is masked; the real terminal (iTerm) is only
+    # recoverable from the server's startup environment.
+    _write_tmux(
+        bin_dir,
+        term="xterm-256color",
+        session="work",
+        window="1",
+        term_program_global="iTerm.app",
+    )
+
+    env = _tmux_env(os.environ.copy(), bin_dir)
+
+    proc = _run(
+        {
+            "title": "Pi",
+            "message": "Allow shell command?",
+            "notification_type": "permission_prompt",
+            "session_id": "s1",
+        },
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    args = notifier_args.read_text().splitlines()
+    assert _arg_after(args, "-activate") == "com.googlecode.iterm2"
+
+    execute = _arg_after(args, "-execute")
+    assert "open -b net.kovidgoyal.kitty" not in execute
+    assert "switch-client" in execute
+    assert "work:1" in execute
+
+
+def test_kitty_via_socket_without_tmux(tmp_path: Path) -> None:
+    import shutil
+    import socket as _socket
+    import tempfile
+
+    # AF_UNIX paths are capped at ~104 chars, so bind under a short /tmp dir
+    # rather than the (long) pytest tmp_path.
+    sock_dir = tempfile.mkdtemp(prefix="ccn-", dir="/tmp")
+    sock_path = Path(sock_dir) / "k.sock"
+    srv = _socket.socket(_socket.AF_UNIX)
+    srv.bind(str(sock_path))
+
+    try:
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        notifier_args = tmp_path / "terminal-notifier.args"
+
+        _write_terminal_notifier(bin_dir, notifier_args)
+        _write_executable(bin_dir / "kitty", "#!/usr/bin/env bash\nexit 0\n")
+
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["KITTY_LISTEN_ON"] = f"unix:{sock_path}"
+        env["KITTY_WINDOW_ID"] = "7"
+        for var in ("TMUX", "TMUX_PANE", "TERM_PROGRAM", "CLAUDE_TERMINAL_BUNDLE_ID"):
+            env.pop(var, None)
+
+        proc = _run(
+            {
+                "title": "Pi",
+                "message": "Allow shell command?",
+                "notification_type": "permission_prompt",
+                "session_id": "s1",
+            },
+            cwd=tmp_path,
+            env=env,
+        )
+
+        assert proc.returncode == 0, proc.stderr
+        args = notifier_args.read_text().splitlines()
+        assert _arg_after(args, "-activate") == "net.kovidgoyal.kitty"
+
+        execute = _arg_after(args, "-execute")
+        assert "open -b net.kovidgoyal.kitty" in execute
+        assert "focus-tab -m window_id:'7'" in execute
+        assert "switch-client" not in execute
+    finally:
+        srv.close()
+        shutil.rmtree(sock_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- keep Pi idle notifications on the generic "Ready for input" message instead of replacing it with the last commit subject
- detect Kitty through tmux client metadata so notification activation opens Kitty instead of Terminal.app
- target the active tmux client, window, and pane when jumping back from the notification
- add a regression test for the tmux + Kitty notification path

## Testing
- uv run pytest tests/hooks/test_notify.py tests/hooks/test_hook_shell_compat.py
- bash -n src/hooks/notify/hook.sh
- uv run python scripts/build/compile.py
